### PR TITLE
fix: Section 엔티티 @Builder.Default 적용으로 빌더 경고 해결 (#26)

### DIFF
--- a/src/main/java/com/server/domain/section/entity/Section.java
+++ b/src/main/java/com/server/domain/section/entity/Section.java
@@ -32,6 +32,7 @@ public class Section {
     private String type; // "place" or "course"
 
     @Column(name = "ui_type")
+    @Builder.Default
     private String uiType = "horizontal";
 
     @Column(name = "sequence")
@@ -46,10 +47,11 @@ public class Section {
     private boolean isHome;
 
     @OneToMany(mappedBy = "section", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<SectionPlace> sectionPlaces = new ArrayList<>();
 
     @OneToMany(mappedBy = "section", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<SectionCourse> sectionCourses = new ArrayList<>();
-
 
 }


### PR DESCRIPTION
Section 엔티티의 uiType, sectionPlaces, sectionCourses 필드에 @Builder.Default 어노테이션을 추가하여 빌더 사용 시 초기값이 무시되는 경고를 해결했습니다.

- 관련 이슈: #26
- 주요 변경점:
  - uiType, sectionPlaces, sectionCourses에 @Builder.Default 적용

리뷰 부탁드립니다.