### PR TITLE
✨ feat: 계정 복구 가능 여부 확인 기능 구현 (UserDto에 restoreEnabled 필드 추가)

### DIFF
--- a/src/main/java/com/server/domain/user/dto/UserDto.java
+++ b/src/main/java/com/server/domain/user/dto/UserDto.java
@@ -16,14 +16,22 @@ import lombok.Setter;
 @Builder
 @AllArgsConstructor
 public class UserDto {
-    public String nickname;
-    public String thumbnail;
+    private String nickname;
+    private String thumbnail;
+    private Boolean restoreEnabled;
     private List<TermAgreementDto> termAgreement;
 
     public static UserDto from(User user) {
+        Boolean restoreEnabled;
+        if (user.getDeletedAt() != null) {
+            restoreEnabled = true;
+        } else {
+            restoreEnabled = false;
+        }
         return UserDto.builder()
                 .nickname(user.getNickname())
                 .thumbnail(user.getThumbnail())
+                .restoreEnabled(restoreEnabled)
                 .termAgreement(user.getTermAgreements().stream()
                         .map(termAgreement -> TermAgreementDto.from(termAgreement))
                         .collect(Collectors.toList()))

--- a/src/main/java/com/server/domain/user/service/UserService.java
+++ b/src/main/java/com/server/domain/user/service/UserService.java
@@ -1,14 +1,13 @@
 package com.server.domain.user.service;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.server.domain.term.entity.Term;
 import com.server.domain.term.entity.TermAgreement;
 import com.server.domain.term.repository.TermAgreementRepository;
-import com.server.domain.term.repository.TermRepository;
 import com.server.domain.user.dto.UserDto;
 import com.server.domain.user.entity.User;
 import com.server.domain.user.repository.UserRepository;
@@ -43,7 +42,9 @@ public class UserService {
     }
 
     public String deleteUser(User user) {
-        userRepository.delete(user);
+        // userRepository.delete(user);
+        user.setDeletedAt(LocalDateTime.now());
+        userRepository.save(user);
         return user.getNickname();
     }
 


### PR DESCRIPTION
## 변경 내용
이슈 #36 관련 계정 복구 가능 여부를 확인하는 기능을 구현했습니다.

### 주요 변경사항
- UserDto에 `restoreEnabled` 필드 추가
- User 엔티티와 DTO 간 매핑 로직 구현
- 삭제된 계정의 복구 가능 여부 판단 로직 적용

## 연관된 이슈
- Closes #36

## 테스트 여부
- [x] 단위 테스트 통과
- [x] 통합 테스트 통과

## 기타 참고사항
- 로그인 후 프론트엔드에서 `restoreEnabled` 값을 기준으로 계정 복구 페이지 이동 여부를 판단할 수 있음