### PR TITLE
Fix: JWT 예외 처리를 GlobalExceptionHandler로 통합

### DIFF
--- a/src/main/java/com/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/server/global/config/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 import com.server.domain.oauth.handler.OAuth2SuccessHandler;
 import com.server.domain.oauth.service.OAuth2UserService;
+import com.server.global.error.handler.FilterChainExceptionHandler;
 import com.server.global.jwt.JwtAuthenticationFilter;
 
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class SecurityConfig {
         private final JwtAuthenticationFilter jwtAuthenticationFilter;
         private final OAuth2UserService oAuth2UserService;
         private final OAuth2SuccessHandler oAuth2SuccessHandler;
+        private final FilterChainExceptionHandler filterChainExceptionHandler;
 
         @Bean
         public WebSecurityCustomizer webSecurityCustomizer() { // security를 적용하지 않을 리소스
@@ -53,6 +55,10 @@ public class SecurityConfig {
                                 .oauth2Login(oauth -> oauth.userInfoEndpoint(
                                                 c -> c.userService(oAuth2UserService))
                                                 .successHandler(oAuth2SuccessHandler))
+                                // 예외 처리 필터를 가장 먼저 추가
+                                .addFilterBefore(filterChainExceptionHandler,
+                                                UsernamePasswordAuthenticationFilter.class)
+                                // JWT 인증 필터는 그 다음에 추가
                                 .addFilterBefore(jwtAuthenticationFilter,
                                                 UsernamePasswordAuthenticationFilter.class);
                 return http.build();

--- a/src/main/java/com/server/global/error/handler/FilterChainExceptionHandler.java
+++ b/src/main/java/com/server/global/error/handler/FilterChainExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.server.global.error.handler;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class FilterChainExceptionHandler extends OncePerRequestFilter {
+
+    @Autowired
+    @Qualifier("handlerExceptionResolver")
+    private HandlerExceptionResolver resolver;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            resolver.resolveException(request, response, null, e);
+        }
+    }
+}


### PR DESCRIPTION
## 변경사항
- JWT 필터에서 발생하는 BusinessException을 GlobalExceptionHandler에서 처리하도록 수정
- 필터 체인에서 발생하는 예외를 Spring MVC의 예외 처리 메커니즘으로 라우팅하는 FilterChainExceptionHandler 추가
- SecurityConfig에 FilterChainExceptionHandler를 등록하여 필터 예외를 GlobalExceptionHandler로 전달

## 관련 이슈
Closes #31