### PR TITLE
✨ 계정 복구 API 개발

### DIFF
--- a/src/main/java/com/server/domain/user/dto/RestoreAccountDto.java
+++ b/src/main/java/com/server/domain/user/dto/RestoreAccountDto.java
@@ -1,0 +1,16 @@
+package com.server.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "계정 복구/삭제 요청 DTO")
+public class RestoreAccountDto {
+
+    @Schema(description = "복구 여부 (true: 복구, false: 삭제)", example = "true")
+    private boolean restore;
+}

--- a/src/main/java/com/server/global/error/code/UserErrorCode.java
+++ b/src/main/java/com/server/global/error/code/UserErrorCode.java
@@ -8,8 +8,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-    NOT_FOUND(HttpStatus.NOT_FOUND.value(),
-            "사용자가 존재하지 않습니다."), INVALID_PARAMETER(HttpStatus.BAD_REQUEST.value(), "잘못된 요청입니다.");
+    NOT_FOUND(HttpStatus.NOT_FOUND.value(), "사용자가 존재하지 않습니다."), INVALID_PARAMETER(
+            HttpStatus.BAD_REQUEST.value(), "잘못된 요청입니다."), ALREADY_ACTIVE(
+                    HttpStatus.BAD_REQUEST.value(), "이미 활성화된 계정입니다."), RESTORATION_PERIOD_EXPIRED(
+                            HttpStatus.GONE.value(), "계정 복구 기간이 만료되었습니다.");
 
     private final int status;
     private final String message;


### PR DESCRIPTION
## 작업 내용
- `UserService`에 계정 복구 메서드 추가
- `restoreAccount` 메서드 구현으로 삭제된 계정 복구 기능 제공
- `deletedAt` 필드를 초기화하는 복구 로직 개발
- 복구 가능 기간(30일) 검증 기능 구현
- API 라우트와 응답 모델 정의

## 구현 사항
1. 계정 복구 API 엔드포인트 추가:
   - `POST /api/users/restore`
   - 이전에 삭제된 계정을 복구하는 기능 제공

2. 복구/삭제 기능 통합:
   - `restore` 플래그로 복구 또는 삭제 작업 결정
   - `true`: 계정 복구
   - `false`: 계정 삭제

3. 검증 기능:
   - 이미 활성화된 계정인지 검사
   - 복구 가능 기간 내인지 검사

## 관련 이슈
Closes #37