### PR TITLE
feat: interpark ticket ranking crawling

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
       - "8080:8080"
     depends_on:
       - postgres
+    volumes:
+      - /Users/ssohee/dev/withiy-crawling:/app/withiy-crawling # 인터파크 티켓 크롤링 정보 파일 가져오기 위한 로컬 위치
 
   postgres:
     image: postgres:latest

--- a/src/main/java/com/server/domain/event/controller/EventController.java
+++ b/src/main/java/com/server/domain/event/controller/EventController.java
@@ -1,0 +1,42 @@
+package com.server.domain.event.controller;
+
+import com.server.domain.category.dto.CategoryDto;
+import com.server.domain.event.dto.EventDto;
+import com.server.domain.event.service.EventService;
+import com.server.global.dto.ApiResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/events")
+public class EventController {
+
+    private final EventService eventService;
+
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')") //추후 관리자로 변경
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping
+    @Operation(summary = "이벤트 저장하기", description = "인터파크 티켓 랭킹 탑 50 기반 1주마다 이벤트 저장")
+    public ApiResponseDto<List<EventDto>> saveEvents() throws Exception {
+        List<EventDto> eventDtos = eventService.saveEvents();
+        return ApiResponseDto.success(HttpStatus.OK.value(), eventDtos);
+    }
+
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping
+    @Operation(summary = "이벤트 정보 가져오기", description = "인터파크 티켓 랭킹 탑 50 기반 각 장르별 이벤트 dto 반환")
+    public ApiResponseDto<List<EventDto>> getEvents() {
+        List<EventDto> eventDtos = eventService.getEvents();
+        return ApiResponseDto.success(HttpStatus.OK.value(), eventDtos);
+    }
+}

--- a/src/main/java/com/server/domain/event/dto/EventDto.java
+++ b/src/main/java/com/server/domain/event/dto/EventDto.java
@@ -1,0 +1,34 @@
+package com.server.domain.event.dto;
+
+import com.server.domain.event.entity.Event;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EventDto {
+    private int ranking;
+    private String genre;
+    private String title;
+    private String place;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String thumbnail;
+
+    public static EventDto from(Event event){
+        return EventDto.builder()
+                .ranking(event.getRanking())
+                .genre(event.getGenre())
+                .title(event.getTitle())
+                .place(event.getPlace())
+                .startDate(event.getStartDate())
+                .endDate(event.getEndDate())
+                .thumbnail(event.getThumbnail())
+                .build();
+    }
+}

--- a/src/main/java/com/server/domain/event/entity/Event.java
+++ b/src/main/java/com/server/domain/event/entity/Event.java
@@ -1,0 +1,47 @@
+package com.server.domain.event.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "event")
+public class Event {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "place")
+    private String place;
+
+    @Column(name = "genre")
+    private String genre;
+
+    @Column(name = "ranking")
+    private int ranking;
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    @Column(name = "thumbnail")
+    private String thumbnail;
+}

--- a/src/main/java/com/server/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/server/domain/event/repository/EventRepository.java
@@ -1,0 +1,8 @@
+package com.server.domain.event.repository;
+
+
+import com.server.domain.event.entity.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+}

--- a/src/main/java/com/server/domain/event/service/EventService.java
+++ b/src/main/java/com/server/domain/event/service/EventService.java
@@ -1,0 +1,109 @@
+package com.server.domain.event.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.server.domain.event.dto.EventDto;
+import com.server.domain.event.entity.Event;
+import com.server.domain.event.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.File;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EventService {
+    private final EventRepository eventRepository;
+
+    public List<EventDto> getEvents() {
+        return eventRepository.findAll()
+                .stream().map(EventDto::from).toList();
+    }
+
+    @Transactional
+    public List<EventDto> saveEvents() throws Exception {
+        List<EventDto> eventDtos = new ArrayList<>();
+        String dirPath = "/app/withiy-crawling";  // 이벤트 랭킹 json 위치
+        ObjectMapper mapper = new ObjectMapper();
+
+        File dir = new File(dirPath);
+        if (!dir.exists() || !dir.isDirectory()) {
+            log.info("디렉토리가 존재하지 않습니다: " + dirPath);
+            return eventDtos;
+        }
+
+        File[] files = dir.listFiles((d, name) -> name.endsWith(".json"));
+        if (files == null) {
+            log.info("JSON 파일이 없습니다: " + dirPath);
+            return eventDtos;
+        }
+
+        for (File file : files) {
+            JsonNode root = mapper.readTree(file);
+            Iterator<JsonNode> iter = root.elements();
+
+            while (iter.hasNext()) {
+                JsonNode node = iter.next();
+                Event event = new Event();
+
+                event.setRanking(node.get("ranking").asInt());
+                event.setGenre(node.get("genre").asText());
+                event.setTitle(node.get("title").asText());
+                event.setPlace(node.get("place").asText());
+                event.setThumbnail(node.get("image").asText());
+
+                // 날짜 파싱
+                String dateStr = node.get("date").asText();
+                LocalDate[] dates = parseDateRange(dateStr);
+                event.setStartDate(dates[0]);
+                event.setEndDate(dates[1]);
+
+                eventRepository.save(event);
+                eventDtos.add(EventDto.from(event));
+            }
+        }
+        return eventDtos;
+    }
+
+    public LocalDate[] parseDateRange(String dateStr) {
+        if (dateStr == null || dateStr.isBlank()) return new LocalDate[]{null, null};
+        String[] parts = dateStr.split("~");
+        String start = parts[0].trim();
+        String end = parts.length > 1 ? parts[1].trim() : null;
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.M.d");
+        LocalDate startDate = null;
+        LocalDate endDate = null;
+
+        // 시작날짜 파싱
+        try {
+            startDate = LocalDate.parse(start, formatter);
+        } catch (Exception e) {
+            // 파싱 실패 시 null
+        }
+
+        // 종료날짜 파싱
+        if (end != null && !end.isBlank()) {
+            // 연도 없는 종료일 처리 (예: 7.13 → 2025.7.13)
+            if (end.chars().filter(ch -> ch == '.').count() == 1 && startDate != null) {
+                int year = startDate.getYear();
+                end = year + "." + end;
+            }
+            try {
+                endDate = LocalDate.parse(end, formatter);
+            } catch (Exception e) {
+                // 파싱 실패 시 null
+            }
+        }
+
+        return new LocalDate[]{startDate, endDate};
+    }
+}


### PR DESCRIPTION
### Features

+ Event
  + FEAT: Event 저장, 불러오기

### Chore
- 인터파크 티켓 크롤링 한 파일 불러와서 event 테이블에 저장 
    - 파이썬에서 selenium, beautifulsoup 이용해 크롤링 -> 로컬에 장르별(콘서트, 뮤지컬, 스포츠, 전시/행사, 연극) json 파일 저장 -> 스프링 부트가 로컬 파일 읽어와서 이벤트 저장 -> 추후 서버에 올려서 로직 변경시켜야함
- event 전체 불러오기
    - EventRepository에 저장된 공연 정보 가져옴

