### PR TITLE
feat: 토큰 갱신(Refresh) API 개발

### DIFF
--- a/src/main/java/com/server/domain/oauth/controller/OAuthController.java
+++ b/src/main/java/com/server/domain/oauth/controller/OAuthController.java
@@ -4,15 +4,20 @@ import java.io.IOException;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.server.domain.oauth.dto.RefreshTokenDto;
 import com.server.domain.oauth.service.AuthService;
 import com.server.global.dto.ApiResponseDto;
+import com.server.global.dto.TokenDto;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 @RequestMapping("/auth")
+@Tag(name = "Authentication", description = "인증 관련 API")
 public class OAuthController {
 
     private final AuthService authService;
@@ -28,10 +34,18 @@ public class OAuthController {
     @ResponseStatus(HttpStatus.FOUND)
     @GetMapping("/success")
     @Operation(hidden = true)
-    public ApiResponseDto<String> getRedirect(@RequestParam String accessToken, @RequestParam String refreshToken,
-            HttpServletResponse response) throws IOException {
+    public ApiResponseDto<String> getRedirect(@RequestParam String accessToken,
+            @RequestParam String refreshToken, HttpServletResponse response) throws IOException {
         String redirectUri = authService.getRedirectUri(accessToken, refreshToken);
         response.sendRedirect(redirectUri);
         return ApiResponseDto.success(HttpStatus.FOUND.value(), redirectUri);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/refresh")
+    @Operation(summary = "토큰 갱신", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급합니다.")
+    public ApiResponseDto<TokenDto> refreshToken(@RequestBody RefreshTokenDto refreshTokenDto) {
+        TokenDto tokenDto = authService.refreshToken(refreshTokenDto.getRefreshToken());
+        return ApiResponseDto.success(HttpStatus.OK.value(), tokenDto);
     }
 }

--- a/src/main/java/com/server/domain/oauth/dto/RefreshTokenDto.java
+++ b/src/main/java/com/server/domain/oauth/dto/RefreshTokenDto.java
@@ -1,0 +1,16 @@
+package com.server.domain.oauth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "Refresh token request DTO")
+public class RefreshTokenDto {
+
+    @Schema(description = "Refresh token", example = "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4...")
+    private String refreshToken;
+}

--- a/src/main/java/com/server/domain/oauth/service/AuthService.java
+++ b/src/main/java/com/server/domain/oauth/service/AuthService.java
@@ -2,17 +2,72 @@ package com.server.domain.oauth.service;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import com.server.domain.user.entity.User;
+import com.server.domain.user.repository.UserRepository;
+import com.server.domain.user.service.UserService;
+import com.server.global.dto.TokenDto;
+import com.server.global.error.code.AuthErrorCode;
+import com.server.global.error.exception.AuthException;
+import com.server.global.jwt.JwtService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 @Service
+@RequiredArgsConstructor
+@Slf4j
 public class AuthService {
     @Value("${spring.security.oauth2.client.frontend-uri}")
     private String frontendUri;
 
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+    private final UserService userService;
+
     public String getRedirectUri(String accessToken, String refreshToken) {
         return UriComponentsBuilder.fromUriString(String.format("%s/auth/callback", frontendUri))
-                .queryParam("accessToken", accessToken)
-                .queryParam("refreshToken", refreshToken).build().toUriString();
+                .queryParam("accessToken", accessToken).queryParam("refreshToken", refreshToken)
+                .build().toUriString();
+    }
 
+    /**
+     * 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급합니다.
+     *
+     * @param refreshToken 리프레시 토큰
+     * @return 새로운 액세스 토큰과 리프레시 토큰
+     * @throws AuthException 리프레시 토큰이 유효하지 않거나 만료된 경우
+     */
+    @Transactional
+    public TokenDto refreshToken(String refreshToken) {
+        // 리프레시 토큰 검증
+        if (!jwtService.validateToken(refreshToken)) {
+            throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // 토큰에서 사용자 ID 추출
+        Long userId = jwtService.extractUserId(refreshToken)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+
+        // 사용자 조회 및 저장된 리프레시 토큰 일치 여부 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+
+        // 저장된 리프레시 토큰과 일치하는지 확인
+        if (user.getRefreshToken() == null || !user.getRefreshToken().equals(refreshToken)) {
+            throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // 새로운 토큰 발급
+        String newAccessToken = jwtService.createAccessToken(userId);
+        String newRefreshToken = jwtService.createRefreshToken(userId);
+
+        // 새로운 리프레시 토큰 저장
+        userService.saveRefreshToken(userId, newRefreshToken);
+
+        log.info("Token refreshed for user ID: {}", userId);
+        return new TokenDto(newAccessToken, newRefreshToken);
     }
 }


### PR DESCRIPTION
## 개요
- 이슈 번호: #43
- 액세스 토큰 만료 시 리프레시 토큰을 통한 토큰 갱신 API 개발

## 작업 내용
1. 리프레시 토큰을 통해 새 액세스 토큰을 발급하는 API 엔드포인트 구현
   - `/auth/refresh` POST 엔드포인트 추가
   - RefreshTokenDto 클래스 생성
2. AuthService에 토큰 갱신 로직 구현
   - 토큰 유효성 검증 및 보안 로직 강화
   - 리프레시 토큰 만료 시 재로그인 요청 처리 로직 개발
   - 토큰 갱신 관련 예외 처리 및 에러 응답 정의

## 테스트 방법
다음 API를 통해 토큰 갱신 테스트 가능:
```
POST /auth/refresh
Content-Type: application/json

{
  "refreshToken": "사용자의_리프레시_토큰"
}
```

응답:
```
{
  "status": 200,
  "message": "Success",
  "data": {
    "accessToken": "새로_발급된_액세스_토큰",
    "refreshToken": "새로_발급된_리프레시_토큰"
  }
}
```

## 관련 이슈
Closes #43
Related to #33