### PR TITLE
[#45] feat: 처음 만난날 지정 커플 연결 API 개발

### DIFF
--- a/src/main/java/com/server/domain/oauth/dto/OAuth2UserInfo.java
+++ b/src/main/java/com/server/domain/oauth/dto/OAuth2UserInfo.java
@@ -2,6 +2,8 @@ package com.server.domain.oauth.dto;
 
 import static com.server.global.error.code.AuthErrorCode.ILLEGAL_REGISTRATION_ID;
 
+import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
@@ -26,7 +28,19 @@ public class OAuth2UserInfo {
     private String provider;
     private String providerId;
 
-    public static OAuth2UserInfo of(String registrationId, String nameAttributeKey, Map<String, Object> attributes) {
+    // 생성되는 코드의 길이 (바이트 단위)
+    private static final int CODE_LENGTH = 16;
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    // URI-safe한 랜덤 문자열을 생성하는 메서드
+    private static String generateRandomCode() {
+        byte[] randomBytes = new byte[CODE_LENGTH];
+        RANDOM.nextBytes(randomBytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
+    }
+
+    public static OAuth2UserInfo of(String registrationId, String nameAttributeKey,
+            Map<String, Object> attributes) {
         return switch (registrationId) { // registration id별로 userInfo 생성
             case "google" -> ofGoogle(registrationId, nameAttributeKey, attributes);
             case "naver" -> ofNaver(registrationId, nameAttributeKey, attributes);
@@ -37,30 +51,20 @@ public class OAuth2UserInfo {
 
     private static OAuth2UserInfo ofGoogle(String registrationId, String nameAttributeKey,
             Map<String, Object> attributes) {
-        return OAuth2UserInfo.builder()
-                .nameAttributeKey(nameAttributeKey)
-                .nickname((String) attributes.get("name"))
-                .email((String) attributes.get("email"))
-                .picture((String) attributes.get("picture"))
-                .provider(registrationId)
-                .attributes(attributes)
-                .providerId((String) attributes.get("sub"))
-                .build();
+        return OAuth2UserInfo.builder().nameAttributeKey(nameAttributeKey)
+                .nickname((String) attributes.get("name")).email((String) attributes.get("email"))
+                .picture((String) attributes.get("picture")).provider(registrationId)
+                .attributes(attributes).providerId((String) attributes.get("sub")).build();
     }
 
     private static OAuth2UserInfo ofNaver(String registrationId, String nameAttributeKey,
             Map<String, Object> attributes) {
         Map<String, Object> response = (Map<String, Object>) attributes.get("response");
 
-        return OAuth2UserInfo.builder()
-                .nameAttributeKey(nameAttributeKey)
-                .nickname((String) response.get("nickname"))
-                .email((String) response.get("email"))
-                .picture((String) response.get("profile_image"))
-                .provider(registrationId)
-                .attributes(attributes)
-                .providerId((String) response.get("id"))
-                .build();
+        return OAuth2UserInfo.builder().nameAttributeKey(nameAttributeKey)
+                .nickname((String) response.get("nickname")).email((String) response.get("email"))
+                .picture((String) response.get("profile_image")).provider(registrationId)
+                .attributes(attributes).providerId((String) response.get("id")).build();
     }
 
     private static OAuth2UserInfo ofKakao(String registrationId, String nameAttributeKey,
@@ -70,32 +74,29 @@ public class OAuth2UserInfo {
 
         String providerId = String.valueOf(attributes.get("id"));
 
-        String email = kakaoAccount.containsKey("email") ? (String) kakaoAccount.get("email") : null;
+        String email =
+                kakaoAccount.containsKey("email") ? (String) kakaoAccount.get("email") : null;
 
-        return OAuth2UserInfo.builder()
-                .nameAttributeKey(nameAttributeKey)
-                .nickname((String) profile.get("nickname"))
-                .email(email)
-                .picture((String) profile.get("profile_image_url"))
-                .provider(registrationId)
-                .attributes(attributes)
-                .providerId(providerId)
-                .build();
+        return OAuth2UserInfo.builder().nameAttributeKey(nameAttributeKey)
+                .nickname((String) profile.get("nickname")).email(email)
+                .picture((String) profile.get("profile_image_url")).provider(registrationId)
+                .attributes(attributes).providerId(providerId).build();
 
     }
 
     public OAuth toEntity(List<Term> terms) {
+        // 사용자 고유 코드 생성
+        String randomCode = generateRandomCode();
+        log.info("새 사용자를 위한 랜덤 코드 생성: {}", randomCode);
 
-        User user = User.builder()
-                .nickname(nickname)
-                .thumbnail(picture)
-                .terms(terms)
-                .build();
-        return OAuth.builder()
-                .provider(provider)
-                .providerId(providerId)
-                .email(email)
-                .user(user)
+        User user =
+                User.builder().nickname(nickname).thumbnail(picture).terms(terms).code(randomCode) // 생성된
+                                                                                                   // 랜덤
+                                                                                                   // 코드
+                                                                                                   // 설정
+                        .build();
+
+        return OAuth.builder().provider(provider).providerId(providerId).email(email).user(user)
                 .build();
 
     }

--- a/src/main/java/com/server/domain/user/controller/CoupleController.java
+++ b/src/main/java/com/server/domain/user/controller/CoupleController.java
@@ -1,0 +1,67 @@
+package com.server.domain.user.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.server.domain.user.dto.CoupleConnectionRequestDto;
+import com.server.domain.user.dto.CoupleDto;
+import com.server.domain.user.entity.User;
+import com.server.domain.user.service.CoupleService;
+import com.server.global.dto.ApiResponseDto;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/couples")
+@Slf4j
+@Tag(name = "Couple", description = "커플 관련 API")
+public class CoupleController {
+
+    private final CoupleService coupleService;
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    @Operation(summary = "커플 연결",
+            description = "사용자 코드를 사용하여 커플을 연결합니다. 선택적으로 처음 만난 날짜를 지정할 수 있습니다.")
+    public ApiResponseDto<CoupleDto> connectCouple(@AuthenticationPrincipal User user,
+            @RequestBody CoupleConnectionRequestDto requestDto) {
+
+        CoupleDto coupleDto = coupleService.connectCouple(user, requestDto.getPartnerCode(),
+                requestDto.getFirstMetDate());
+
+        return ApiResponseDto.success(HttpStatus.CREATED.value(), coupleDto);
+    }
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping
+    @Operation(summary = "커플 정보 조회", description = "현재 로그인한 사용자의 커플 관계 정보를 조회합니다.")
+    public ApiResponseDto<CoupleDto> getCouple(@AuthenticationPrincipal User user) {
+        CoupleDto coupleDto = coupleService.getCouple(user);
+
+        return ApiResponseDto.success(HttpStatus.OK.value(), coupleDto);
+    }
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @ResponseStatus(HttpStatus.OK)
+    @DeleteMapping
+    @Operation(summary = "커플 연결 해제", description = "현재 로그인한 사용자의 커플 관계를 해제합니다.")
+    public ApiResponseDto<Long> disconnectCouple(@AuthenticationPrincipal User user) {
+        Long coupleId = coupleService.disconnectCouple(user);
+
+        return ApiResponseDto.success(HttpStatus.OK.value(), coupleId);
+    }
+}

--- a/src/main/java/com/server/domain/user/controller/CoupleController.java
+++ b/src/main/java/com/server/domain/user/controller/CoupleController.java
@@ -5,6 +5,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.server.domain.user.dto.CoupleConnectionRequestDto;
 import com.server.domain.user.dto.CoupleDto;
+import com.server.domain.user.dto.FirstMetDateUpdateDto;
 import com.server.domain.user.entity.User;
 import com.server.domain.user.service.CoupleService;
 import com.server.global.dto.ApiResponseDto;
@@ -39,8 +41,7 @@ public class CoupleController {
     public ApiResponseDto<CoupleDto> connectCouple(@AuthenticationPrincipal User user,
             @RequestBody CoupleConnectionRequestDto requestDto) {
 
-        CoupleDto coupleDto = coupleService.connectCouple(user, requestDto.getPartnerCode(),
-                requestDto.getFirstMetDate());
+        CoupleDto coupleDto = coupleService.connectCouple(user, requestDto.getPartnerCode());
 
         return ApiResponseDto.success(HttpStatus.CREATED.value(), coupleDto);
     }
@@ -63,5 +64,17 @@ public class CoupleController {
         Long coupleId = coupleService.disconnectCouple(user);
 
         return ApiResponseDto.success(HttpStatus.OK.value(), coupleId);
+    }
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @ResponseStatus(HttpStatus.OK)
+    @PatchMapping("/first-met-date")
+    @Operation(summary = "처음 만난 날짜 설정", description = "이미 연결된 커플의 처음 만난 날짜를 설정하거나 변경합니다.")
+    public ApiResponseDto<CoupleDto> updateFirstMetDate(@AuthenticationPrincipal User user,
+            @RequestBody FirstMetDateUpdateDto requestDto) {
+
+        CoupleDto coupleDto = coupleService.updateFirstMetDate(user, requestDto.getFirstMetDate());
+
+        return ApiResponseDto.success(HttpStatus.OK.value(), coupleDto);
     }
 }

--- a/src/main/java/com/server/domain/user/dto/CoupleConnectionRequestDto.java
+++ b/src/main/java/com/server/domain/user/dto/CoupleConnectionRequestDto.java
@@ -1,0 +1,27 @@
+package com.server.domain.user.dto;
+
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CoupleConnectionRequestDto {
+
+    @Schema(description = "상대방 유저 고유 코드", example = "ABC123")
+    private String partnerCode;
+
+    @Schema(description = "처음 만난 날짜 (선택사항)", example = "2025-01-01")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate firstMetDate;
+}

--- a/src/main/java/com/server/domain/user/dto/CoupleDto.java
+++ b/src/main/java/com/server/domain/user/dto/CoupleDto.java
@@ -1,0 +1,49 @@
+package com.server.domain.user.dto;
+
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.server.domain.user.entity.Couple;
+import com.server.domain.user.entity.User;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CoupleDto {
+
+    @Schema(description = "커플 고유 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "파트너 닉네임", example = "파트너닉네임")
+    private String partnerNickname;
+
+    @Schema(description = "파트너 프로필 이미지", example = "https://example.com/profile.jpg")
+    private String partnerThumbnail;
+
+    @Schema(description = "처음 만난 날짜", example = "2025-01-01")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate firstMetDate;
+
+    @Schema(description = "연결된 날짜", example = "2025-04-29")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate connectedDate;
+
+    // 현재 사용자 기준으로 파트너 정보를 반환하는 팩토리 메서드
+    public static CoupleDto from(Couple couple, User currentUser) {
+        User partner = couple.getUser1().getId().equals(currentUser.getId()) ? couple.getUser2()
+                : couple.getUser1();
+
+        return CoupleDto.builder().id(couple.getId()).partnerNickname(partner.getNickname())
+                .partnerThumbnail(partner.getThumbnail()).firstMetDate(couple.getFirstMetDate())
+                .connectedDate(couple.getCreatedAt().toLocalDate()).build();
+    }
+}

--- a/src/main/java/com/server/domain/user/dto/FirstMetDateUpdateDto.java
+++ b/src/main/java/com/server/domain/user/dto/FirstMetDateUpdateDto.java
@@ -16,8 +16,9 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class CoupleConnectionRequestDto {
+public class FirstMetDateUpdateDto {
 
-    @Schema(description = "상대방 유저 고유 코드", example = "ABC123")
-    private String partnerCode;
+    @Schema(description = "설정할 처음 만난 날짜", example = "2025-01-01")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate firstMetDate;
 }

--- a/src/main/java/com/server/domain/user/dto/UserDto.java
+++ b/src/main/java/com/server/domain/user/dto/UserDto.java
@@ -16,6 +16,7 @@ public class UserDto {
     private String thumbnail;
     private Boolean restoreEnabled;
     private Boolean isRegistered;
+    private String code;
 
     public static UserDto from(User user, Boolean isRegistered) {
         Boolean restoreEnabled;
@@ -25,6 +26,7 @@ public class UserDto {
             restoreEnabled = false;
         }
         return UserDto.builder().nickname(user.getNickname()).thumbnail(user.getThumbnail())
-                .restoreEnabled(restoreEnabled).isRegistered(isRegistered).build();
+                .restoreEnabled(restoreEnabled).isRegistered(isRegistered).code(user.getCode())
+                .build();
     }
 }

--- a/src/main/java/com/server/domain/user/entity/Couple.java
+++ b/src/main/java/com/server/domain/user/entity/Couple.java
@@ -1,0 +1,63 @@
+package com.server.domain.user.entity;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "couple")
+public class Couple {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user1_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user1;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user2_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user2;
+
+    @Column(name = "first_met_date")
+    private LocalDate firstMetDate;
+
+    @Column(name = "created_at", nullable = false)
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/server/domain/user/entity/User.java
+++ b/src/main/java/com/server/domain/user/entity/User.java
@@ -22,6 +22,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -71,13 +72,23 @@ public class User {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true,
+            fetch = FetchType.LAZY)
     @JsonIgnore
     private List<OAuth> oAuth;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true,
+            fetch = FetchType.EAGER)
     @JsonIgnore
     private List<TermAgreement> termAgreements = new ArrayList<>();
+
+    @OneToOne(mappedBy = "user1", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JsonIgnore
+    private Couple coupleAsUser1;
+
+    @OneToOne(mappedBy = "user2", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JsonIgnore
+    private Couple coupleAsUser2;
 
     @Builder
     public User(String nickname, String thumbnail, List<Term> terms) {
@@ -91,5 +102,13 @@ public class User {
 
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
+    }
+
+    public Couple getCouple() {
+        return coupleAsUser1 != null ? coupleAsUser1 : coupleAsUser2;
+    }
+
+    public boolean isConnectedCouple() {
+        return coupleAsUser1 != null || coupleAsUser2 != null;
     }
 }

--- a/src/main/java/com/server/domain/user/entity/User.java
+++ b/src/main/java/com/server/domain/user/entity/User.java
@@ -91,10 +91,11 @@ public class User {
     private Couple coupleAsUser2;
 
     @Builder
-    public User(String nickname, String thumbnail, List<Term> terms) {
+    public User(String nickname, String thumbnail, List<Term> terms, String code) {
         this.nickname = nickname;
         this.thumbnail = thumbnail;
         this.isAdmin = false;
+        this.code = code;
         for (Term term : terms) {
             this.termAgreements.add(TermAgreement.builder().user(this).term(term).build());
         }

--- a/src/main/java/com/server/domain/user/repository/CoupleRepository.java
+++ b/src/main/java/com/server/domain/user/repository/CoupleRepository.java
@@ -5,15 +5,13 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.server.domain.user.entity.Couple;
 import com.server.domain.user.entity.User;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface CoupleRepository extends JpaRepository<Couple, Long> {
 
-    Optional<User> findById(Long id);
+    Optional<Couple> findByUser1OrUser2(User user1, User user2);
 
-    Optional<User> findByNickname(String nickname);
-
-    Optional<User> findByCode(String code);
-
+    boolean existsByUser1OrUser2(User user1, User user2);
 }

--- a/src/main/java/com/server/domain/user/service/CoupleService.java
+++ b/src/main/java/com/server/domain/user/service/CoupleService.java
@@ -33,7 +33,7 @@ public class CoupleService {
      * @return 생성된 커플 정보를 담은 DTO
      */
     @Transactional
-    public CoupleDto connectCouple(User user, String partnerCode, LocalDate firstMetDate) {
+    public CoupleDto connectCouple(User user, String partnerCode) {
         // 1. 현재 유저가 이미 커플인지 확인
         if (user.isConnectedCouple()) {
             throw new BusinessException(CoupleErrorCode.ALREADY_CONNECTED);
@@ -54,8 +54,7 @@ public class CoupleService {
         }
 
         // 5. 커플 생성 및 저장
-        Couple couple =
-                Couple.builder().user1(user).user2(partner).firstMetDate(firstMetDate).build();
+        Couple couple = Couple.builder().user1(user).user2(partner).firstMetDate(null).build();
 
         coupleRepository.save(couple);
         log.info("새로운 커플이 연결되었습니다. 유저1: {}, 유저2: {}", user.getNickname(), partner.getNickname());
@@ -93,5 +92,27 @@ public class CoupleService {
         log.info("커플이 해제되었습니다. 커플 ID: {}", coupleId);
 
         return coupleId;
+    }
+
+    /**
+     * 커플의 처음 만난 날짜를 업데이트합니다.
+     * 
+     * @param user 현재 사용자
+     * @param firstMetDate 설정할 처음 만난 날짜
+     * @return 업데이트된 커플 정보를 담은 DTO
+     */
+    @Transactional
+    public CoupleDto updateFirstMetDate(User user, LocalDate firstMetDate) {
+        // 커플 관계 확인
+        Couple couple = coupleRepository.findByUser1OrUser2(user, user)
+                .orElseThrow(() -> new BusinessException(CoupleErrorCode.COUPLE_NOT_FOUND));
+
+        // 처음 만난 날짜 업데이트
+        couple.setFirstMetDate(firstMetDate);
+        coupleRepository.save(couple);
+
+        log.info("커플 ID: {}의 처음 만난 날짜가 {}로 업데이트되었습니다.", couple.getId(), firstMetDate);
+
+        return CoupleDto.from(couple, user);
     }
 }

--- a/src/main/java/com/server/domain/user/service/CoupleService.java
+++ b/src/main/java/com/server/domain/user/service/CoupleService.java
@@ -1,0 +1,97 @@
+package com.server.domain.user.service;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.server.domain.user.dto.CoupleDto;
+import com.server.domain.user.entity.Couple;
+import com.server.domain.user.entity.User;
+import com.server.domain.user.repository.CoupleRepository;
+import com.server.domain.user.repository.UserRepository;
+import com.server.global.error.code.CoupleErrorCode;
+import com.server.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CoupleService {
+
+    private final CoupleRepository coupleRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 사용자 코드로 커플 연결을 시도합니다.
+     * 
+     * @param user 현재 사용자
+     * @param partnerCode 연결할 파트너의 사용자 코드
+     * @param firstMetDate 처음 만난 날짜 (선택사항)
+     * @return 생성된 커플 정보를 담은 DTO
+     */
+    @Transactional
+    public CoupleDto connectCouple(User user, String partnerCode, LocalDate firstMetDate) {
+        // 1. 현재 유저가 이미 커플인지 확인
+        if (user.isConnectedCouple()) {
+            throw new BusinessException(CoupleErrorCode.ALREADY_CONNECTED);
+        }
+
+        // 2. 상대방 유저 조회
+        User partner = userRepository.findByCode(partnerCode)
+                .orElseThrow(() -> new BusinessException(CoupleErrorCode.PARTNER_NOT_FOUND));
+
+        // 3. 자기 자신과의 연결 시도 방지
+        if (user.getId().equals(partner.getId())) {
+            throw new BusinessException(CoupleErrorCode.SELF_CONNECTION_NOT_ALLOWED);
+        }
+
+        // 4. 상대방이 이미 커플인지 확인
+        if (partner.isConnectedCouple()) {
+            throw new BusinessException(CoupleErrorCode.PARTNER_ALREADY_CONNECTED);
+        }
+
+        // 5. 커플 생성 및 저장
+        Couple couple =
+                Couple.builder().user1(user).user2(partner).firstMetDate(firstMetDate).build();
+
+        coupleRepository.save(couple);
+        log.info("새로운 커플이 연결되었습니다. 유저1: {}, 유저2: {}", user.getNickname(), partner.getNickname());
+
+        return CoupleDto.from(couple, user);
+    }
+
+    /**
+     * 현재 사용자의 커플 정보를 조회합니다.
+     * 
+     * @param user 현재 사용자
+     * @return 커플 정보를 담은 DTO
+     */
+    @Transactional(readOnly = true)
+    public CoupleDto getCouple(User user) {
+        Couple couple = coupleRepository.findByUser1OrUser2(user, user)
+                .orElseThrow(() -> new BusinessException(CoupleErrorCode.COUPLE_NOT_FOUND));
+
+        return CoupleDto.from(couple, user);
+    }
+
+    /**
+     * 커플 연결을 해제합니다.
+     * 
+     * @param user 현재 사용자
+     * @return 해제된 커플의 ID
+     */
+    @Transactional
+    public Long disconnectCouple(User user) {
+        Couple couple = coupleRepository.findByUser1OrUser2(user, user)
+                .orElseThrow(() -> new BusinessException(CoupleErrorCode.COUPLE_NOT_FOUND));
+
+        Long coupleId = couple.getId();
+        coupleRepository.delete(couple);
+        log.info("커플이 해제되었습니다. 커플 ID: {}", coupleId);
+
+        return coupleId;
+    }
+}

--- a/src/main/java/com/server/global/error/code/CoupleErrorCode.java
+++ b/src/main/java/com/server/global/error/code/CoupleErrorCode.java
@@ -1,0 +1,22 @@
+package com.server.global.error.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CoupleErrorCode implements ErrorCode {
+
+    ALREADY_CONNECTED(HttpStatus.BAD_REQUEST.value(), "이미 커플로 연결된 사용자입니다."), PARTNER_NOT_FOUND(
+            HttpStatus.NOT_FOUND.value(),
+            "해당 코드를 가진 사용자를 찾을 수 없습니다."), PARTNER_ALREADY_CONNECTED(HttpStatus.BAD_REQUEST.value(),
+                    "상대방이 이미 커플로 연결된 사용자입니다."), SELF_CONNECTION_NOT_ALLOWED(
+                            HttpStatus.BAD_REQUEST.value(),
+                            "자기 자신과 커플 연결을 할 수 없습니다."), COUPLE_NOT_FOUND(
+                                    HttpStatus.NOT_FOUND.value(), "연결된 커플을 찾을 수 없습니다.");
+
+    private final int status;
+    private final String message;
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #45

## 작업 내용
처음 만난날 지정을 통한 커플 연결 API를 개발했습니다.

## 구현 세부사항
1. 커플 연결을 위한 엔티티 및 리포지토리 구현
   - `Couple` 엔티티 클래스 및 `CoupleRepository` 생성
   - `User` 엔티티에 커플 관계 참조 추가

2. 커플 연결 API 엔드포인트 구현
   - `POST /api/couples`: 상대방 코드를 통한 커플 연결 (선택적 처음 만난날 지정)
   - `GET /api/couples`: 현재 연결된 커플 정보 조회
   - `DELETE /api/couples`: 커플 관계 해제
   - `PATCH /api/couples/first-met-date`: 기존 커플의 처음 만난 날짜 별도 수정

3. 선택적 기능으로 처음 만난날 지정 구현
   - 기획 요구사항에 따라 필수 입력이 아닌 선택 입력으로 구현
   - 별도 엔드포인트를 통해 후속 수정 가능하도록 구현

4. 사용자별 고유 코드 생성 기능 구현
   - URI-safe한 랜덤 문자열 생성 (Base64 URL-safe 인코딩)
   - OAuth 로그인 시 자동 생성되도록 설정
   - `UserDto`에 코드 필드 추가하여 API 응답에 포함

5. 커플 연결 상태 처리 및 오류 처리
   - 커플 관련 예외 상황에 대한 에러 코드 및 메시지 정의
   - 이미 연결된 사용자, 존재하지 않는 사용자 코드 등 예외 처리


## 리뷰어를 위한 참고사항
- 처음 만난 날짜는 필수 입력이 아니며, 별도 엔드포인트를 통해 나중에도 수정 가능합니다.
- 사용자 코드는 OAuth 로그인 시 자동 생성되어 `GET /api/users/me`를 통해 확인할 수 있습니다.