### PR TITLE
[#34] 계정 자동 삭제 기능 구현 (Cron)

### DIFF
--- a/src/main/java/com/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/server/domain/user/repository/UserRepository.java
@@ -1,5 +1,7 @@
 package com.server.domain.user.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,4 +18,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByCode(String code);
 
+    // Find soft-deleted users whose deletedAt date is before the specified date
+    List<User> findByDeletedAtNotNullAndDeletedAtBefore(LocalDateTime date);
 }

--- a/src/main/java/com/server/domain/user/service/UserService.java
+++ b/src/main/java/com/server/domain/user/service/UserService.java
@@ -2,8 +2,10 @@ package com.server.domain.user.service;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Map;
 
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -133,5 +135,49 @@ public class UserService {
         log.info("User account restored successfully: {}", user.getNickname());
 
         return user.getNickname();
+    }
+
+    /**
+     * 매일 새벽 3시에 복구 기간이 만료된 삭제된 계정을 영구 삭제하는 스케줄링 작업 Cron 표현식: 초 분 시 일 월 요일
+     */
+    @Scheduled(cron = "0 0 3 * * ?")
+    @Transactional
+    public void purgeExpiredAccounts() {
+        log.info("Starting scheduled task to purge expired user accounts");
+        try {
+            // 복구 기간(30일)이 지난 계정 계산
+            LocalDateTime expirationThreshold =
+                    LocalDateTime.now().minus(ACCOUNT_RESTORATION_PERIOD_DAYS, ChronoUnit.DAYS);
+
+            // 만료된 계정 목록 조회
+            List<User> expiredUsers =
+                    userRepository.findByDeletedAtNotNullAndDeletedAtBefore(expirationThreshold);
+
+            if (expiredUsers.isEmpty()) {
+                log.info("No expired accounts found for permanent deletion");
+                return;
+            }
+
+            log.info("Found {} expired user accounts scheduled for permanent deletion",
+                    expiredUsers.size());
+
+            // 만료된 계정 영구 삭제
+            for (User user : expiredUsers) {
+                try {
+                    log.info(
+                            "Permanently deleting expired user account: ID={}, Nickname={}, DeletedAt={}",
+                            user.getId(), user.getNickname(), user.getDeletedAt());
+                    userRepository.delete(user);
+                } catch (Exception e) {
+                    log.error("Error while deleting expired user account ID={}: {}", user.getId(),
+                            e.getMessage(), e);
+                }
+            }
+
+            log.info("Completed purging expired user accounts. Total accounts processed: {}",
+                    expiredUsers.size());
+        } catch (Exception e) {
+            log.error("Error during scheduled account purge task: {}", e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/com/server/global/config/SchedulerConfig.java
+++ b/src/main/java/com/server/global/config/SchedulerConfig.java
@@ -1,0 +1,10 @@
+package com.server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+    // This configuration enables Spring's scheduling capabilities
+}

--- a/src/test/java/com/server/domain/user/service/UserServiceSchedulerTest.java
+++ b/src/test/java/com/server/domain/user/service/UserServiceSchedulerTest.java
@@ -1,0 +1,110 @@
+package com.server.domain.user.service;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.server.domain.term.repository.TermAgreementRepository;
+import com.server.domain.user.entity.User;
+import com.server.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceSchedulerTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TermAgreementRepository termAgreementRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("만료된 계정 자동 영구 삭제 - 30일 이상 삭제된 계정 제거")
+    void purgeExpiredAccounts_shouldDeleteAccountsOlderThan30Days() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime thirtyOneDaysAgo = now.minus(31, ChronoUnit.DAYS);
+
+        User expiredUser = new User();
+        expiredUser.setId(1L);
+        expiredUser.setNickname("ExpiredUser");
+        expiredUser.setDeletedAt(thirtyOneDaysAgo);
+
+        // 시간 정확도 문제를 해결하기 위해 any() 사용
+        when(userRepository.findByDeletedAtNotNullAndDeletedAtBefore(any(LocalDateTime.class)))
+                .thenReturn(Collections.singletonList(expiredUser));
+
+        // when
+        userService.purgeExpiredAccounts();
+
+        // then
+        // 시간 비교를 피하고 메소드가 호출되었는지만 확인
+        verify(userRepository, times(1))
+                .findByDeletedAtNotNullAndDeletedAtBefore(any(LocalDateTime.class));
+        verify(userRepository, times(1)).delete(expiredUser);
+    }
+
+    @Test
+    @DisplayName("예외 발생시 다른 계정 삭제 작업에 영향을 주지 않도록 함")
+    void purgeExpiredAccounts_shouldHandleExceptions() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime thirtyOneDaysAgo = now.minus(31, ChronoUnit.DAYS);
+
+        User user1 = new User();
+        user1.setId(1L);
+        user1.setNickname("User1");
+        user1.setDeletedAt(thirtyOneDaysAgo);
+
+        User user2 = new User();
+        user2.setId(2L);
+        user2.setNickname("User2");
+        user2.setDeletedAt(thirtyOneDaysAgo);
+
+        // 시간 정확도 문제를 해결하기 위해 any() 사용
+        when(userRepository.findByDeletedAtNotNullAndDeletedAtBefore(any(LocalDateTime.class)))
+                .thenReturn(Arrays.asList(user1, user2));
+
+        // user1 삭제시 예외가 발생하도록 설정
+        doThrow(new RuntimeException("Database error")).when(userRepository).delete(user1);
+
+        // when
+        userService.purgeExpiredAccounts();
+
+        // then
+        // user1에서 예외가 발생해도 user2는 삭제 시도해야 함
+        verify(userRepository, times(1)).delete(user1); // 예외가 발생하더라도 호출되는지 확인
+        verify(userRepository, times(1)).delete(user2);
+    }
+
+    @Test
+    @DisplayName("만료된 계정이 없는 경우 삭제 작업이 수행되지 않음")
+    void purgeExpiredAccounts_shouldNotDeleteWhenNoExpiredAccounts() {
+        // given
+        // 시간 정확도 문제를 해결하기 위해 any() 사용
+        when(userRepository.findByDeletedAtNotNullAndDeletedAtBefore(any(LocalDateTime.class)))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        userService.purgeExpiredAccounts();
+
+        // then
+        verify(userRepository, times(0)).delete(any(User.class));
+    }
+}


### PR DESCRIPTION
## 계정 자동 삭제 기능 구현

### 변경사항
- 계정 복구 가능 기간(30일)이 만료된 계정을 자동으로 영구 삭제하는 스케줄링 작업(Cron) 구현
- 매일 새벽 3시에 실행되도록 설정 (`@Scheduled(cron = "0 0 3 * * ?")`)
- DB에서 완전히 삭제되어 복구 불가능한 상태로 만듦

### 구현 세부사항
1. `UserRepository`에 만료된 계정을 찾는 메소드 추가
   - `findByDeletedAtNotNullAndDeletedAtBefore` 메소드로 삭제된 지 30일 이상 지난 계정 조회
2. 스케줄링 설정 클래스 추가
   - `SchedulerConfig` 클래스에 `@EnableScheduling` 설정
3. `UserService`에 자동 삭제 기능 구현
   - `purgeExpiredAccounts` 메소드에서 만료된 계정 확인 및 삭제
   - 예외 처리와 로깅 추가하여 작업 진행 상황 추적
4. 테스트 케이스 구현
   - 만료된 계정이 정상적으로 삭제되는지 테스트
   - 예외 발생 시 다른 계정 삭제 작업에 영향을 주지 않는지 테스트
   - 만료된 계정이 없는 경우 삭제 작업이 수행되지 않는지 테스트

### 참고사항
- 기존 코드에서 사용 중인 `ACCOUNT_RESTORATION_PERIOD_DAYS` 상수(30일)를 재활용
- 연관된 데이터는 User 엔티티에 이미 설정된 cascade 옵션을 통해 함께 삭제

Closes #34