### PR TITLE
Test: 섹션 도메인 테스트 코드 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/main/java/com/server/domain/category/dto/CreateCategoryDto.java
+++ b/src/main/java/com/server/domain/category/dto/CreateCategoryDto.java
@@ -2,9 +2,15 @@ package com.server.domain.category.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 
 @Getter
+@Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class CreateCategoryDto {
     private String name;
     private String icon;

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -15,16 +15,16 @@ spring:
         frontend-uri: "https://test-front"
         registration:
           google:
-            client-id: ${GOOGLE_CLIENT_ID}
-            client-secret: ${GOOGLE_CLIENT_SECRET}
+            client-id: test-google-id
+            client-secret: test-google-secret
             redirect-uri: "${BACKEND_URI}/login/oauth2/code/google"
             authorization-grant-type: authorization_code
             scope:
               - email
               - profile
           naver:
-            client-id: ${NAVER_CLIENT_ID}
-            client-secret: ${NAVER_CLIENT_SECRET}
+            client-id: test-naver-id
+            client-secret: test-naver-secret
             redirect-uri: "${BACKEND_URI}/login/oauth2/code/naver"
             authorization-grant-type: authorization_code
             client-name: Naver
@@ -33,8 +33,8 @@ spring:
               - email
               - profile_image
           kakao:
-            client-id: ${KAKAO_CLIENT_ID}
-            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-id: test-kakao-id
+            client-secret: test-kakao-secret
             redirect-uri: "${BACKEND_URI}/login/oauth2/code/kakao"
             authorization-grant-type: authorization_code
             client-name: Kakao

--- a/src/test/java/com/server/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/server/domain/category/controller/CategoryControllerTest.java
@@ -1,0 +1,148 @@
+package com.server.domain.category.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.server.domain.category.dto.CategoryDto;
+import com.server.domain.category.dto.CreateCategoryDto;
+import com.server.domain.category.service.CategoryService;
+import com.server.domain.user.controller.JwtTestUtil;
+import com.server.domain.user.controller.TestJpaConfig;
+import com.server.domain.user.controller.TestSecurityConfig;
+import com.server.domain.user.entity.User;
+import com.server.global.dto.ApiResponseDto;
+import com.server.global.error.exception.BusinessException;
+import com.server.global.error.code.UserErrorCode;
+import com.server.global.jwt.JwtAuthentication;
+import com.server.global.jwt.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import({TestSecurityConfig.class, TestJpaConfig.class})
+class CategoryControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CategoryService categoryService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    private User mockUser;
+
+    @BeforeEach
+    void setUp() {
+        // 각 테스트 전에 MockMvc를 재설정
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+
+        // 테스트용 사용자 설정
+        mockUser = new User();
+        mockUser.setId(1L);
+        mockUser.setNickname("testUser");
+        mockUser.setThumbnail("thumbnail.jpg");
+        mockUser.setCode("USER123");
+        mockUser.setAdmin(false);
+
+        // JWT 서비스 설정
+        when(jwtService.createAccessToken(anyLong())).thenReturn("mock-jwt-token");
+
+        // 기본 인증 설정
+        SecurityContextHolder.getContext().setAuthentication(
+                new JwtAuthentication(mockUser, AuthorityUtils.createAuthorityList("ROLE_USER")));
+    }
+
+    @Test
+    @DisplayName("카테고리 목록 조회 테스트")
+    void getCategories_shouldReturnAllCategories() throws Exception {
+        // given
+        CategoryDto category1 = CategoryDto.builder().id(1L).name("카테고리1").icon("icon1").build();
+
+        CategoryDto category2 = CategoryDto.builder().id(2L).name("카테고리2").icon("icon2").build();
+
+        List<CategoryDto> categoryList = Arrays.asList(category1, category2);
+
+        when(categoryService.getCategories()).thenReturn(categoryList);
+
+        // when & then
+        MvcResult result = mockMvc
+                .perform(get("/api/categories").with(JwtTestUtil.withJwt(jwtService, mockUser))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk()).andDo(print()).andReturn();
+
+        String content = result.getResponse().getContentAsString();
+        ApiResponseDto<List<CategoryDto>> response = objectMapper.readValue(content,
+                objectMapper.getTypeFactory().constructParametricType(ApiResponseDto.class,
+                        objectMapper.getTypeFactory().constructCollectionType(List.class,
+                                CategoryDto.class)));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getData()).hasSize(2);
+        assertThat(response.getData().get(0).getId()).isEqualTo(1L);
+        verify(categoryService, times(1)).getCategories();
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 테스트")
+    void createCategory_shouldCreateAndReturnCategory() throws Exception {
+        // given
+        CreateCategoryDto createRequest =
+                CreateCategoryDto.builder().name("새 카테고리").icon("new_icon").build();
+
+        CategoryDto createdCategory =
+                CategoryDto.builder().id(1L).name("새 카테고리").icon("new_icon").build();
+
+        when(categoryService.createCategory(any(CreateCategoryDto.class)))
+                .thenReturn(createdCategory);
+
+        // when & then
+        MvcResult result = mockMvc
+                .perform(post("/api/categories").with(JwtTestUtil.withJwt(jwtService, mockUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest)))
+                .andExpect(status().isOk()).andDo(print()).andReturn();
+
+        String content = result.getResponse().getContentAsString();
+        ApiResponseDto<CategoryDto> response = objectMapper.readValue(content, objectMapper
+                .getTypeFactory().constructParametricType(ApiResponseDto.class, CategoryDto.class));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getData().getId()).isEqualTo(1L);
+        verify(categoryService, times(1)).createCategory(any(CreateCategoryDto.class));
+    }
+}

--- a/src/test/java/com/server/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/server/domain/category/service/CategoryServiceTest.java
@@ -1,0 +1,89 @@
+package com.server.domain.category.service;
+
+import com.server.domain.category.dto.CategoryDto;
+import com.server.domain.category.dto.CreateCategoryDto;
+import com.server.domain.category.entity.Category;
+import com.server.domain.category.repository.CategoryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private CategoryService categoryService;
+
+    @Test
+    @DisplayName("카테고리 생성 테스트")
+    void createCategory_shouldReturnCategoryDto() {
+        // given
+        CreateCategoryDto createCategoryDto =
+                CreateCategoryDto.builder().name("테스트 카테고리").icon("test_icon").build();
+
+        Category savedCategory = new Category("테스트 카테고리", "test_icon");
+        // ID 직접 설정
+        ReflectionTestUtils.setField(savedCategory, "id", 1L);
+
+        // mock 설정: CategoryRepository.save() 호출 시 savedCategory 반환하도록 설정
+        when(categoryRepository.save(any(Category.class))).thenAnswer(invocation -> {
+            Category argument = invocation.getArgument(0);
+            // 저장 시 ID 설정 (실제 DB 동작 시뮬레이션)
+            ReflectionTestUtils.setField(argument, "id", 1L);
+            return argument;
+        });
+
+        // when
+        CategoryDto result = categoryService.createCategory(createCategoryDto);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getName()).isEqualTo("테스트 카테고리");
+        assertThat(result.getIcon()).isEqualTo("test_icon");
+        verify(categoryRepository, times(1)).save(any(Category.class));
+    }
+
+    @Test
+    @DisplayName("모든 카테고리 조회 테스트")
+    void getCategories_shouldReturnAllCategories() {
+        // given
+        Category category1 = new Category("카테고리1", "icon1");
+        ReflectionTestUtils.setField(category1, "id", 1L);
+
+        Category category2 = new Category("카테고리2", "icon2");
+        ReflectionTestUtils.setField(category2, "id", 2L);
+
+        List<Category> categoryList = Arrays.asList(category1, category2);
+
+        when(categoryRepository.findAll()).thenReturn(categoryList);
+
+        // when
+        List<CategoryDto> result = categoryService.getCategories();
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.get(0).getId()).isEqualTo(1L);
+        assertThat(result.get(0).getName()).isEqualTo("카테고리1");
+        assertThat(result.get(0).getIcon()).isEqualTo("icon1");
+        assertThat(result.get(1).getId()).isEqualTo(2L);
+        assertThat(result.get(1).getName()).isEqualTo("카테고리2");
+        assertThat(result.get(1).getIcon()).isEqualTo("icon2");
+        verify(categoryRepository, times(1)).findAll();
+    }
+}

--- a/src/test/java/com/server/domain/event/controller/EventControllerTest.java
+++ b/src/test/java/com/server/domain/event/controller/EventControllerTest.java
@@ -1,0 +1,105 @@
+package com.server.domain.event.controller;
+
+import com.server.domain.event.dto.EventDto;
+import com.server.domain.event.service.EventService;
+import com.server.global.dto.ApiResponseDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class EventControllerTest {
+
+    @Mock
+    private EventService eventService;
+
+    @InjectMocks
+    private EventController eventController;
+
+    private MockMvc mockMvc;
+    private List<EventDto> sampleEvents;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(eventController).build();
+
+        sampleEvents = new ArrayList<>();
+        sampleEvents.add(EventDto.builder().ranking(1).genre("콘서트").title("Sample Concert")
+                .place("Seoul Arena").startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusDays(30)).thumbnail("http://example.com/image.jpg")
+                .build());
+
+        sampleEvents.add(EventDto.builder().ranking(2).genre("뮤지컬").title("Sample Musical")
+                .place("LG Arts Center").startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusDays(60)).thumbnail("http://example.com/musical.jpg")
+                .build());
+    }
+
+    @Test
+    @DisplayName("이벤트 정보 가져오기 성공 테스트")
+    void getEventsSuccessTest() {
+        // Given
+        when(eventService.getEvents()).thenReturn(sampleEvents);
+
+        // When
+        ApiResponseDto<List<EventDto>> response = eventController.getEvents();
+
+        // Then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals(sampleEvents.size(), response.getData().size());
+        assertEquals(sampleEvents.get(0).getTitle(), response.getData().get(0).getTitle());
+        assertEquals(sampleEvents.get(1).getGenre(), response.getData().get(1).getGenre());
+    }
+
+    @Test
+    @DisplayName("이벤트 저장하기 성공 테스트")
+    void saveEventsSuccessTest() throws Exception {
+        // Given
+        when(eventService.saveEvents()).thenReturn(sampleEvents);
+
+        // When
+        ApiResponseDto<List<EventDto>> response = eventController.saveEvents();
+
+        // Then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals(sampleEvents.size(), response.getData().size());
+        assertEquals(sampleEvents.get(0).getTitle(), response.getData().get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("이벤트 API 엔드포인트 GET 접근 테스트")
+    void getEventsEndpointTest() throws Exception {
+        // Given
+        when(eventService.getEvents()).thenReturn(sampleEvents);
+
+        // When & Then
+        mockMvc.perform(get("/api/events")).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("이벤트 API 엔드포인트 POST 접근 테스트")
+    void saveEventsEndpointTest() throws Exception {
+        // Given
+        when(eventService.saveEvents()).thenReturn(sampleEvents);
+
+        // When & Then
+        mockMvc.perform(post("/api/events")).andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/server/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/server/domain/event/service/EventServiceTest.java
@@ -1,0 +1,299 @@
+package com.server.domain.event.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.server.domain.event.dto.EventDto;
+import com.server.domain.event.entity.Event;
+import com.server.domain.event.repository.EventRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class EventServiceTest {
+
+    @Mock
+    private EventRepository eventRepository;
+
+    // We'll use a TestEventService to override the hardcoded path
+    private class TestEventService extends EventService {
+        private String customDirPath;
+        private final Logger logger = LoggerFactory.getLogger(TestEventService.class);
+
+        public TestEventService(EventRepository eventRepository) {
+            super(eventRepository);
+        }
+
+        public void setCustomDirPath(String customDirPath) {
+            this.customDirPath = customDirPath;
+        }
+
+        @Override
+        public List<EventDto> saveEvents() throws Exception {
+            // Override the path with our custom path
+            List<EventDto> eventDtos = new ArrayList<>();
+            String dirPath =
+                    this.customDirPath != null ? this.customDirPath : "/app/withiy-crawling";
+            ObjectMapper mapper = new ObjectMapper();
+
+            File dir = new File(dirPath);
+            if (!dir.exists() || !dir.isDirectory()) {
+                logger.info("디렉토리가 존재하지 않습니다: " + dirPath);
+                return eventDtos;
+            }
+
+            File[] files = dir.listFiles((d, name) -> name.endsWith(".json"));
+            if (files == null) {
+                logger.info("JSON 파일이 없습니다: " + dirPath);
+                return eventDtos;
+            }
+
+            for (File file : files) {
+                JsonNode root = mapper.readTree(file);
+                Iterator<JsonNode> iter = root.elements();
+
+                while (iter.hasNext()) {
+                    JsonNode node = iter.next();
+                    Event event = new Event();
+
+                    event.setRanking(node.get("ranking").asInt());
+                    event.setGenre(node.get("genre").asText());
+                    event.setTitle(node.get("title").asText());
+                    event.setPlace(node.get("place").asText());
+                    event.setThumbnail(node.get("image").asText());
+
+                    // 날짜 파싱
+                    String dateStr = node.get("date").asText();
+                    LocalDate[] dates = parseDateRange(dateStr);
+                    event.setStartDate(dates[0]);
+                    event.setEndDate(dates[1]);
+
+                    eventRepository.save(event);
+                    eventDtos.add(EventDto.from(event));
+                }
+            }
+            return eventDtos;
+        }
+    }
+
+    private TestEventService eventService;
+    private List<Event> sampleEvents;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        eventService = new TestEventService(eventRepository);
+
+        sampleEvents = new ArrayList<>();
+
+        Event event1 = new Event();
+        event1.setId(1L);
+        event1.setRanking(1);
+        event1.setGenre("콘서트");
+        event1.setTitle("Sample Concert");
+        event1.setPlace("Seoul Arena");
+        event1.setStartDate(LocalDate.of(2025, 5, 1));
+        event1.setEndDate(LocalDate.of(2025, 6, 1));
+        event1.setThumbnail("http://example.com/image.jpg");
+
+        Event event2 = new Event();
+        event2.setId(2L);
+        event2.setRanking(2);
+        event2.setGenre("뮤지컬");
+        event2.setTitle("Sample Musical");
+        event2.setPlace("LG Arts Center");
+        event2.setStartDate(LocalDate.of(2025, 5, 15));
+        event2.setEndDate(LocalDate.of(2025, 7, 15));
+        event2.setThumbnail("http://example.com/musical.jpg");
+
+        sampleEvents.add(event1);
+        sampleEvents.add(event2);
+    }
+
+    @Test
+    @DisplayName("이벤트 정보 가져오기 테스트")
+    void getEventsTest() {
+        // Given
+        when(eventRepository.findAll()).thenReturn(sampleEvents);
+
+        // When
+        List<EventDto> result = eventService.getEvents();
+
+        // Then
+        assertEquals(2, result.size());
+        assertEquals("Sample Concert", result.get(0).getTitle());
+        assertEquals("뮤지컬", result.get(1).getGenre());
+        assertEquals(LocalDate.of(2025, 5, 1), result.get(0).getStartDate());
+        assertEquals(LocalDate.of(2025, 7, 15), result.get(1).getEndDate());
+
+        verify(eventRepository, times(1)).findAll();
+    }
+
+    @Test
+    @DisplayName("날짜 파싱 - 정상 범위 테스트")
+    void parseDateRangeNormalTest() {
+        // Given
+        String dateStr = "2025.5.1~2025.6.30";
+
+        // When
+        LocalDate[] dates = eventService.parseDateRange(dateStr);
+
+        // Then
+        assertEquals(LocalDate.of(2025, 5, 1), dates[0]);
+        assertEquals(LocalDate.of(2025, 6, 30), dates[1]);
+    }
+
+    @Test
+    @DisplayName("날짜 파싱 - 종료일 연도 누락 테스트")
+    void parseDateRangeMissingYearTest() {
+        // Given
+        String dateStr = "2025.5.1~6.30";
+
+        // When
+        LocalDate[] dates = eventService.parseDateRange(dateStr);
+
+        // Then
+        assertEquals(LocalDate.of(2025, 5, 1), dates[0]);
+        assertEquals(LocalDate.of(2025, 6, 30), dates[1]);
+    }
+
+    @Test
+    @DisplayName("날짜 파싱 - 단일 날짜 테스트")
+    void parseDateRangeSingleDateTest() {
+        // Given
+        String dateStr = "2025.5.1";
+
+        // When
+        LocalDate[] dates = eventService.parseDateRange(dateStr);
+
+        // Then
+        assertEquals(LocalDate.of(2025, 5, 1), dates[0]);
+        assertNull(dates[1]);
+    }
+
+    @Test
+    @DisplayName("날짜 파싱 - 빈 문자열 테스트")
+    void parseDateRangeEmptyStringTest() {
+        // Given
+        String dateStr = "";
+
+        // When
+        LocalDate[] dates = eventService.parseDateRange(dateStr);
+
+        // Then
+        assertNull(dates[0]);
+        assertNull(dates[1]);
+    }
+
+    @Test
+    @DisplayName("날짜 파싱 - null 테스트")
+    void parseDateRangeNullTest() {
+        // When
+        LocalDate[] dates = eventService.parseDateRange(null);
+
+        // Then
+        assertNull(dates[0]);
+        assertNull(dates[1]);
+    }
+
+    @Test
+    @DisplayName("날짜 파싱 - 잘못된 형식 테스트")
+    void parseDateRangeInvalidFormatTest() {
+        // Given
+        String dateStr = "Invalid date format";
+
+        // When
+        LocalDate[] dates = eventService.parseDateRange(dateStr);
+
+        // Then
+        assertNull(dates[0]);
+        assertNull(dates[1]);
+    }
+
+    @Test
+    @DisplayName("이벤트 저장 - 디렉토리 없을 때 테스트")
+    void saveEventsDirectoryNotExistTest() throws Exception {
+        // Given - 존재하지 않는 경로로 설정
+        String nonExistentPath = "/non/existent/path";
+        eventService.setCustomDirPath(nonExistentPath);
+
+        // When
+        List<EventDto> result = eventService.saveEvents();
+
+        // Then
+        assertTrue(result.isEmpty());
+        verify(eventRepository, never()).save(any(Event.class));
+    }
+
+    @Test
+    @DisplayName("이벤트 저장 테스트")
+    void saveEventsTest(@TempDir Path tempDir) throws Exception {
+        // Given
+        // 임시 디렉토리 경로로 설정
+        String tempDirPath = tempDir.toString();
+        eventService.setCustomDirPath(tempDirPath);
+
+        // 샘플 JSON 파일 생성
+        ObjectNode eventNode1 = objectMapper.createObjectNode();
+        eventNode1.put("ranking", 1);
+        eventNode1.put("genre", "콘서트");
+        eventNode1.put("title", "Test Concert");
+        eventNode1.put("place", "Test Arena");
+        eventNode1.put("image", "http://example.com/test.jpg");
+        eventNode1.put("date", "2025.5.1~2025.6.1");
+
+        ObjectNode eventNode2 = objectMapper.createObjectNode();
+        eventNode2.put("ranking", 2);
+        eventNode2.put("genre", "뮤지컬");
+        eventNode2.put("title", "Test Musical");
+        eventNode2.put("place", "Test Center");
+        eventNode2.put("image", "http://example.com/test2.jpg");
+        eventNode2.put("date", "2025.7.1~8.31");
+
+        ArrayNode arrayNode = objectMapper.createArrayNode();
+        arrayNode.add(eventNode1);
+        arrayNode.add(eventNode2);
+
+        File testFile = tempDir.resolve("test.json").toFile();
+        objectMapper.writeValue(testFile, arrayNode);
+
+        when(eventRepository.save(any(Event.class))).thenAnswer(invocation -> {
+            Event savedEvent = invocation.getArgument(0);
+            savedEvent.setId(1L); // DB에서 ID 할당 시뮬레이션
+            return savedEvent;
+        });
+
+        // When
+        List<EventDto> result = eventService.saveEvents();
+
+        // Then
+        assertEquals(2, result.size());
+        assertEquals("Test Concert", result.get(0).getTitle());
+        assertEquals("뮤지컬", result.get(1).getGenre());
+
+        verify(eventRepository, times(2)).save(any(Event.class));
+    }
+}

--- a/src/test/java/com/server/domain/section/controller/SectionControllerTest.java
+++ b/src/test/java/com/server/domain/section/controller/SectionControllerTest.java
@@ -1,0 +1,167 @@
+package com.server.domain.section.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.server.domain.category.dto.CategoryDto;
+import com.server.domain.section.dto.CreateSectionDto;
+import com.server.domain.section.dto.HomeSectionDto;
+import com.server.domain.section.dto.SectionDto;
+import com.server.domain.section.service.SectionService;
+import com.server.domain.user.controller.JwtTestUtil;
+import com.server.domain.user.controller.TestJpaConfig;
+import com.server.domain.user.controller.TestSecurityConfig;
+import com.server.domain.user.entity.User;
+import com.server.global.dto.ApiResponseDto;
+import com.server.global.jwt.JwtAuthentication;
+import com.server.global.jwt.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import({TestSecurityConfig.class, TestJpaConfig.class})
+class SectionControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private SectionService sectionService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    private User mockUser;
+
+    @BeforeEach
+    void setUp() {
+        // 각 테스트 전에 MockMvc를 재설정
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+
+        // 테스트용 사용자 설정
+        mockUser = new User();
+        mockUser.setId(1L);
+        mockUser.setNickname("testUser");
+        mockUser.setThumbnail("thumbnail.jpg");
+        mockUser.setCode("USER123");
+        mockUser.setAdmin(true); // Admin 권한 부여 (섹션 생성에 필요)
+
+        // JWT 서비스 설정
+        when(jwtService.createAccessToken(anyLong())).thenReturn("mock-jwt-token");
+
+        // 기본 인증 설정
+        SecurityContextHolder.getContext().setAuthentication(
+                new JwtAuthentication(mockUser, AuthorityUtils.createAuthorityList("ROLE_ADMIN")));
+    }
+
+    @Test
+    @DisplayName("홈 섹션 목록 조회 테스트")
+    void getHomeSections_shouldReturnAllHomeSections() throws Exception {
+        // given
+        CategoryDto category =
+                CategoryDto.builder().id(1L).name("맛집").icon("restaurant_icon").build();
+
+        HomeSectionDto section1 = HomeSectionDto.builder().id(1L).title("인기 맛집").type("place")
+                .order(1).uiType("horizontal").category(category).places(Collections.emptyList())
+                .courses(Collections.emptyList()).build();
+
+        HomeSectionDto section2 = HomeSectionDto.builder().id(2L).title("추천 코스").type("course")
+                .order(2).uiType("horizontal").category(category).places(Collections.emptyList())
+                .courses(Collections.emptyList()).build();
+
+        List<HomeSectionDto> sectionList = Arrays.asList(section1, section2);
+
+        when(sectionService.getHomeSections()).thenReturn(sectionList);
+
+        // when & then
+        MvcResult result = mockMvc
+                .perform(get("/api/sections/home").contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andExpect(status().isOk()).andDo(print()).andReturn();
+
+        String content =
+                result.getResponse().getContentAsString(java.nio.charset.StandardCharsets.UTF_8);
+        ApiResponseDto<List<HomeSectionDto>> response = objectMapper.readValue(content,
+                objectMapper.getTypeFactory().constructParametricType(ApiResponseDto.class,
+                        objectMapper.getTypeFactory().constructCollectionType(List.class,
+                                HomeSectionDto.class)));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getData()).hasSize(2);
+        assertThat(response.getData().get(0).getId()).isEqualTo(1L);
+        assertThat(response.getData().get(1).getId()).isEqualTo(2L);
+        verify(sectionService, times(1)).getHomeSections();
+    }
+
+    @Test
+    @DisplayName("섹션 생성 테스트")
+    void createSection_shouldCreateAndReturnSection() throws Exception {
+        // given
+        CategoryDto categoryDto = CategoryDto.builder().id(1L).name("맛집").build();
+
+        CreateSectionDto createRequest = new CreateSectionDto();
+        ReflectionTestUtils.setField(createRequest, "title", "새 맛집 섹션");
+        ReflectionTestUtils.setField(createRequest, "type", "place");
+        ReflectionTestUtils.setField(createRequest, "order", 3);
+        ReflectionTestUtils.setField(createRequest, "categoryId", 1L);
+        ReflectionTestUtils.setField(createRequest, "home", true);
+
+        SectionDto createdSection = SectionDto.builder().title("새 맛집 섹션").type("place")
+                .uiType("horizontal").categoryDto(categoryDto).places(Collections.emptyList())
+                .courses(Collections.emptyList()).build();
+
+        when(sectionService.createSection(any(CreateSectionDto.class))).thenReturn(createdSection);
+
+        // when & then
+        MvcResult result = mockMvc
+                .perform(post("/api/sections").with(JwtTestUtil.withJwt(jwtService, mockUser))
+                        .contentType(MediaType.APPLICATION_JSON).characterEncoding("UTF-8")
+                        .content(objectMapper.writeValueAsString(createRequest)))
+                .andExpect(status().isOk()).andDo(print()).andReturn();
+
+        String content =
+                result.getResponse().getContentAsString(java.nio.charset.StandardCharsets.UTF_8);
+        ApiResponseDto<SectionDto> response = objectMapper.readValue(content, objectMapper
+                .getTypeFactory().constructParametricType(ApiResponseDto.class, SectionDto.class));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getData().getTitle()).isEqualTo("새 맛집 섹션");
+        assertThat(response.getData().getType()).isEqualTo("place");
+        verify(sectionService, times(1)).createSection(any(CreateSectionDto.class));
+    }
+}

--- a/src/test/java/com/server/domain/section/service/SectionServiceTest.java
+++ b/src/test/java/com/server/domain/section/service/SectionServiceTest.java
@@ -1,0 +1,231 @@
+package com.server.domain.section.service;
+
+import com.server.domain.category.dto.CategoryDto;
+import com.server.domain.category.entity.Category;
+import com.server.domain.category.repository.CategoryRepository;
+import com.server.domain.section.dto.CreateSectionDto;
+import com.server.domain.section.dto.HomeSectionDto;
+import com.server.domain.section.dto.SectionDto;
+import com.server.domain.section.entity.Section;
+import com.server.domain.section.repository.SectionCourseRepository;
+import com.server.domain.section.repository.SectionPlaceRepository;
+import com.server.domain.section.repository.SectionRepository;
+import com.server.global.error.code.CategoryErrorCode;
+import com.server.global.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SectionServiceTest {
+
+    @Mock
+    private SectionRepository sectionRepository;
+
+    @Mock
+    private SectionPlaceRepository sectionPlaceRepository;
+
+    @Mock
+    private SectionCourseRepository sectionCourseRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private SectionService sectionService;
+
+    @Test
+    @DisplayName("홈 섹션 조회 테스트")
+    void getHomeSections_shouldReturnAllHomeSections() {
+        // given
+        Category category = new Category("맛집", "restaurant_icon");
+        ReflectionTestUtils.setField(category, "id", 1L);
+
+        Section section1 = Section.builder().title("인기 맛집").type("place").uiType("horizontal")
+                .sequence(1).category(category).isHome(true).build();
+        ReflectionTestUtils.setField(section1, "id", 1L);
+
+        Section section2 = Section.builder().title("추천 코스").type("course").uiType("horizontal")
+                .sequence(2).category(category).isHome(true).build();
+        ReflectionTestUtils.setField(section2, "id", 2L);
+
+        List<Section> homeSections = Arrays.asList(section1, section2);
+
+        when(sectionRepository.findByIsHome(true)).thenReturn(Optional.of(homeSections));
+        when(sectionPlaceRepository.findAllBySectionId(anyLong()))
+                .thenReturn(Optional.of(Collections.emptyList()));
+        when(sectionCourseRepository.findAllBySectionId(anyLong()))
+                .thenReturn(Optional.of(Collections.emptyList()));
+
+        // when
+        List<HomeSectionDto> result = sectionService.getHomeSections();
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.get(0).getId()).isEqualTo(1L);
+        assertThat(result.get(0).getTitle()).isEqualTo("인기 맛집");
+        assertThat(result.get(0).getType()).isEqualTo("place");
+        assertThat(result.get(1).getId()).isEqualTo(2L);
+        assertThat(result.get(1).getTitle()).isEqualTo("추천 코스");
+        assertThat(result.get(1).getType()).isEqualTo("course");
+
+        verify(sectionRepository, times(1)).findByIsHome(true);
+        verify(sectionPlaceRepository, times(1)).findAllBySectionId(1L);
+        verify(sectionCourseRepository, times(1)).findAllBySectionId(2L);
+    }
+
+    @Test
+    @DisplayName("홈 섹션이 없을 때 빈 리스트 반환 테스트")
+    void getHomeSections_whenNoSections_shouldReturnEmptyList() {
+        // given
+        when(sectionRepository.findByIsHome(true)).thenReturn(Optional.of(Collections.emptyList()));
+
+        // when
+        List<HomeSectionDto> result = sectionService.getHomeSections();
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+
+        verify(sectionRepository, times(1)).findByIsHome(true);
+        verify(sectionPlaceRepository, never()).findAllBySectionId(anyLong());
+        verify(sectionCourseRepository, never()).findAllBySectionId(anyLong());
+    }
+
+    @Test
+    @DisplayName("섹션 생성 테스트")
+    void createSection_shouldReturnSectionDto() {
+        // given
+        Category category = new Category("맛집", "restaurant_icon");
+        ReflectionTestUtils.setField(category, "id", 1L);
+
+        CreateSectionDto createSectionDto = new CreateSectionDto();
+        ReflectionTestUtils.setField(createSectionDto, "title", "새 맛집 섹션");
+        ReflectionTestUtils.setField(createSectionDto, "type", "place");
+        ReflectionTestUtils.setField(createSectionDto, "order", 3);
+        ReflectionTestUtils.setField(createSectionDto, "categoryId", 1L);
+        ReflectionTestUtils.setField(createSectionDto, "home", true);
+
+        Section savedSection = Section.builder().title("새 맛집 섹션").type("place").uiType("horizontal")
+                .sequence(3).category(category).isHome(true).build();
+        ReflectionTestUtils.setField(savedSection, "id", 3L);
+
+        when(categoryRepository.findById(1L)).thenReturn(Optional.of(category));
+        when(sectionRepository.save(any(Section.class))).thenReturn(savedSection);
+
+        // when
+        SectionDto result = sectionService.createSection(createSectionDto);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getTitle()).isEqualTo("새 맛집 섹션");
+        assertThat(result.getType()).isEqualTo("place");
+        assertThat(result.getUiType()).isEqualTo("horizontal");
+        assertThat(result.getCategoryDto().getId()).isEqualTo(1L);
+
+        verify(categoryRepository, times(1)).findById(1L);
+        verify(sectionRepository, times(1)).save(any(Section.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 카테고리로 섹션 생성 시 예외 발생 테스트")
+    void createSection_withNonExistentCategory_shouldThrowException() {
+        // given
+        CreateSectionDto createSectionDto = new CreateSectionDto();
+        ReflectionTestUtils.setField(createSectionDto, "title", "새 맛집 섹션");
+        ReflectionTestUtils.setField(createSectionDto, "type", "place");
+        ReflectionTestUtils.setField(createSectionDto, "order", 3);
+        ReflectionTestUtils.setField(createSectionDto, "categoryId", 999L); // 존재하지 않는 카테고리 ID
+        ReflectionTestUtils.setField(createSectionDto, "home", true);
+
+        when(categoryRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            sectionService.createSection(createSectionDto);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(CategoryErrorCode.NOT_FOUND);
+
+        verify(categoryRepository, times(1)).findById(999L);
+        verify(sectionRepository, never()).save(any(Section.class));
+    }
+
+    @Test
+    @DisplayName("섹션을 DTO로 변환 테스트 - 장소 타입")
+    void convertToSectionDto_withPlaceType_shouldConvertCorrectly() {
+        // given
+        Category category = new Category("맛집", "restaurant_icon");
+        ReflectionTestUtils.setField(category, "id", 1L);
+
+        Section section = Section.builder().title("인기 맛집").type("place").uiType("horizontal")
+                .sequence(1).category(category).isHome(true).build();
+        ReflectionTestUtils.setField(section, "id", 1L);
+
+        when(sectionPlaceRepository.findAllBySectionId(1L))
+                .thenReturn(Optional.of(Collections.emptyList()));
+
+        // when
+        SectionDto result = sectionService.convertToSectionDto(section);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getTitle()).isEqualTo("인기 맛집");
+        assertThat(result.getType()).isEqualTo("place");
+        assertThat(result.getUiType()).isEqualTo("horizontal");
+        assertThat(result.getCategoryDto().getId()).isEqualTo(1L);
+        assertThat(result.getCategoryDto().getName()).isEqualTo("맛집");
+        assertThat(result.getPlaces()).isNotNull();
+        assertThat(result.getCourses()).isNotNull();
+
+        verify(sectionPlaceRepository, times(1)).findAllBySectionId(1L);
+        verify(sectionCourseRepository, never()).findAllBySectionId(anyLong());
+    }
+
+    @Test
+    @DisplayName("섹션을 DTO로 변환 테스트 - 코스 타입")
+    void convertToSectionDto_withCourseType_shouldConvertCorrectly() {
+        // given
+        Category category = new Category("코스", "course_icon");
+        ReflectionTestUtils.setField(category, "id", 2L);
+
+        Section section = Section.builder().title("추천 코스").type("course").uiType("horizontal")
+                .sequence(2).category(category).isHome(true).build();
+        ReflectionTestUtils.setField(section, "id", 2L);
+
+        when(sectionCourseRepository.findAllBySectionId(2L))
+                .thenReturn(Optional.of(Collections.emptyList()));
+
+        // when
+        SectionDto result = sectionService.convertToSectionDto(section);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getTitle()).isEqualTo("추천 코스");
+        assertThat(result.getType()).isEqualTo("course");
+        assertThat(result.getUiType()).isEqualTo("horizontal");
+        assertThat(result.getCategoryDto().getId()).isEqualTo(2L);
+        assertThat(result.getCategoryDto().getName()).isEqualTo("코스");
+        assertThat(result.getPlaces()).isNotNull();
+        assertThat(result.getCourses()).isNotNull();
+
+        verify(sectionPlaceRepository, never()).findAllBySectionId(anyLong());
+        verify(sectionCourseRepository, times(1)).findAllBySectionId(2L);
+    }
+}

--- a/src/test/java/com/server/domain/term/controller/TermControllerTest.java
+++ b/src/test/java/com/server/domain/term/controller/TermControllerTest.java
@@ -1,0 +1,82 @@
+package com.server.domain.term.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.server.domain.term.dto.TermDto;
+import com.server.domain.term.service.TermService;
+import com.server.domain.user.controller.TestJpaConfig;
+import com.server.domain.user.controller.TestSecurityConfig;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import({TestSecurityConfig.class, TestJpaConfig.class})
+public class TermControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TermService termService;
+
+    @BeforeEach
+    void setUp() {
+        // 각 테스트 전에 MockMvc를 재설정
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+    }
+
+    @Test
+    @DisplayName("약관 목록 조회 테스트")
+    void getTermsTest() throws Exception {
+        // Mock 데이터 준비
+        List<String> content1 = Arrays.asList("내용1-1", "내용1-2");
+        List<String> content2 = Arrays.asList("내용2-1", "내용2-2");
+
+        TermDto term1 =
+                TermDto.builder().id(1L).title("서비스 이용약관").content(content1).required(true).build();
+
+        TermDto term2 = TermDto.builder().id(2L).title("개인정보 처리방침").content(content2).required(true)
+                .build();
+
+        List<TermDto> terms = Arrays.asList(term1, term2);
+
+        // 서비스 Mock 설정
+        when(termService.getAllTerms()).thenReturn(terms);
+
+        // API 요청 실행 및 검증
+        mockMvc.perform(get("/api/term")).andDo(print()).andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].title").value("서비스 이용약관"))
+                .andExpect(jsonPath("$.data[0].content[0]").value("내용1-1"))
+                .andExpect(jsonPath("$.data[0].required").value(true))
+                .andExpect(jsonPath("$.data[1].id").value(2))
+                .andExpect(jsonPath("$.data[1].title").value("개인정보 처리방침"));
+    }
+}

--- a/src/test/java/com/server/domain/term/service/TermServiceTest.java
+++ b/src/test/java/com/server/domain/term/service/TermServiceTest.java
@@ -1,0 +1,73 @@
+package com.server.domain.term.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.server.domain.term.dto.TermDto;
+import com.server.domain.term.entity.Term;
+import com.server.domain.term.repository.TermRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class TermServiceTest {
+
+    @Mock
+    private TermRepository termRepository;
+
+    @InjectMocks
+    private TermService termService;
+
+    private Term term1;
+    private Term term2;
+    private List<Term> termList;
+
+    @BeforeEach
+    void setUp() {
+        // Mock 데이터 준비
+        term1 = new Term(1L, "서비스 이용약관", "내용1-1||내용1-2", true);
+        term2 = new Term(2L, "개인정보 처리방침", "내용2-1||내용2-2", true);
+        termList = Arrays.asList(term1, term2);
+    }
+
+    @Test
+    @DisplayName("모든 약관 조회 테스트")
+    void getAllTermsTest() {
+        // Mock 설정
+        when(termRepository.findAll()).thenReturn(termList);
+
+        // 서비스 메소드 호출
+        List<TermDto> result = termService.getAllTerms();
+
+        // 검증
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+        // 첫 번째 약관 검증
+        assertEquals(1L, result.get(0).getId());
+        assertEquals("서비스 이용약관", result.get(0).getTitle());
+        assertEquals(2, result.get(0).getContent().size());
+        assertEquals("내용1-1", result.get(0).getContent().get(0));
+        assertEquals("내용1-2", result.get(0).getContent().get(1));
+        assertEquals(true, result.get(0).isRequired());
+
+        // 두 번째 약관 검증
+        assertEquals(2L, result.get(1).getId());
+        assertEquals("개인정보 처리방침", result.get(1).getTitle());
+        assertEquals(2, result.get(1).getContent().size());
+        assertEquals("내용2-1", result.get(1).getContent().get(0));
+        assertEquals("내용2-2", result.get(1).getContent().get(1));
+        assertEquals(true, result.get(1).isRequired());
+    }
+}

--- a/src/test/java/com/server/domain/user/controller/CoupleControllerTest.java
+++ b/src/test/java/com/server/domain/user/controller/CoupleControllerTest.java
@@ -1,0 +1,153 @@
+package com.server.domain.user.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.server.domain.user.dto.CoupleConnectionRequestDto;
+import com.server.domain.user.dto.CoupleDto;
+import com.server.domain.user.dto.FirstMetDateUpdateDto;
+import com.server.domain.user.entity.User;
+import com.server.domain.user.service.CoupleService;
+import com.server.global.jwt.JwtAuthentication;
+import com.server.global.jwt.JwtService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import({TestSecurityConfig.class, TestJpaConfig.class})
+public class CoupleControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CoupleService coupleService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    private User mockUser;
+    private CoupleDto mockCoupleDto;
+
+    @BeforeEach
+    void setUp() {
+        // 각 테스트 전에 MockMvc를 재설정
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+
+        // Setup mock User
+        mockUser = new User();
+        mockUser.setId(1L);
+        mockUser.setNickname("testUser");
+        mockUser.setThumbnail("thumbnail.jpg");
+        mockUser.setCode("USER123");
+        mockUser.setAdmin(false);
+
+        // Setup mock CoupleDto
+        mockCoupleDto = CoupleDto.builder().id(1L).partnerNickname("partnerName")
+                .partnerThumbnail("partner_thumbnail.jpg").firstMetDate(LocalDate.of(2025, 1, 1))
+                .connectedDate(LocalDate.now()).build();
+
+        // Setup JWT service to return a valid token for any user ID
+        when(jwtService.createAccessToken(any(Long.class))).thenReturn("mock-jwt-token");
+
+        // 기본 인증 설정
+        Authentication auth =
+                new JwtAuthentication(mockUser, AuthorityUtils.createAuthorityList("ROLE_USER"));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @Test
+    @DisplayName("Connect couple test")
+    void connectCoupleTest() throws Exception {
+        // Setup mock data
+        CoupleConnectionRequestDto requestDto = new CoupleConnectionRequestDto();
+        requestDto.setPartnerCode("PARTNER_CODE");
+
+        // Setup mock coupleService behavior
+        when(coupleService.connectCouple(any(User.class), any(String.class)))
+                .thenReturn(mockCoupleDto);
+
+        // Execute request with JWT authentication and verify response
+        mockMvc.perform(post("/api/couples").with(JwtTestUtil.withJwt(jwtService, mockUser))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto))).andDo(print())
+                .andExpect(status().isCreated()).andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.partnerNickname").value("partnerName"));
+    }
+
+    @Test
+    @DisplayName("Get couple information test")
+    void getCoupleTest() throws Exception {
+        // Setup mock coupleService behavior
+        when(coupleService.getCouple(any(User.class))).thenReturn(mockCoupleDto);
+
+        // Execute request with JWT authentication and verify response
+        mockMvc.perform(get("/api/couples").with(JwtTestUtil.withJwt(jwtService, mockUser)))
+                .andDo(print()).andExpect(status().isOk()).andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.partnerNickname").value("partnerName"));
+    }
+
+    @Test
+    @DisplayName("Disconnect couple test")
+    void disconnectCoupleTest() throws Exception {
+        // Setup mock coupleService behavior
+        when(coupleService.disconnectCouple(any(User.class))).thenReturn(1L);
+
+        // Execute request with JWT authentication and verify response
+        mockMvc.perform(delete("/api/couples").with(JwtTestUtil.withJwt(jwtService, mockUser)))
+                .andDo(print()).andExpect(status().isOk()).andExpect(jsonPath("$.data").value(1));
+    }
+
+    @Test
+    @DisplayName("Update first met date test")
+    void updateFirstMetDateTest() throws Exception {
+        // Setup mock data
+        FirstMetDateUpdateDto requestDto = new FirstMetDateUpdateDto();
+        requestDto.setFirstMetDate(LocalDate.of(2024, 12, 25));
+
+        // Setup mock coupleService behavior
+        when(coupleService.updateFirstMetDate(any(User.class), any(LocalDate.class)))
+                .thenReturn(mockCoupleDto);
+
+        // Execute request with JWT authentication and verify response
+        mockMvc.perform(
+                patch("/api/couples/first-met-date").with(JwtTestUtil.withJwt(jwtService, mockUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andDo(print()).andExpect(status().isOk()).andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.partnerNickname").value("partnerName"));
+    }
+}

--- a/src/test/java/com/server/domain/user/controller/JwtSecurityMockMvcRequestPostProcessors.java
+++ b/src/test/java/com/server/domain/user/controller/JwtSecurityMockMvcRequestPostProcessors.java
@@ -1,0 +1,40 @@
+package com.server.domain.user.controller;
+
+import java.util.Collection;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import com.server.domain.user.entity.User;
+import com.server.global.jwt.JwtAuthentication;
+
+/**
+ * Custom security utilities for JWT authentication in tests
+ */
+public class JwtSecurityMockMvcRequestPostProcessors {
+
+    /**
+     * Create a RequestPostProcessor that uses a JWT Authentication with the provided user
+     */
+    public static RequestPostProcessor jwt(User user) {
+        return request -> {
+            SecurityContext context = SecurityContextHolder.getContext();
+            Collection<GrantedAuthority> authorities =
+                    user.isAdmin() ? AuthorityUtils.createAuthorityList("ROLE_ADMIN")
+                            : AuthorityUtils.createAuthorityList("ROLE_USER");
+
+            Authentication auth = new JwtAuthentication(user, authorities);
+            context.setAuthentication(auth);
+
+            // Also apply spring security's CSRF protection
+            request = SecurityMockMvcRequestPostProcessors.csrf().postProcessRequest(request);
+
+            return request;
+        };
+    }
+}

--- a/src/test/java/com/server/domain/user/controller/JwtTestUtil.java
+++ b/src/test/java/com/server/domain/user/controller/JwtTestUtil.java
@@ -1,0 +1,57 @@
+package com.server.domain.user.controller;
+
+import com.server.domain.user.entity.User;
+import com.server.global.jwt.JwtAuthentication;
+import com.server.global.jwt.JwtService;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+/**
+ * JWT 관련 테스트를 위한 유틸리티 클래스
+ */
+public class JwtTestUtil {
+
+    /**
+     * 테스트용 JWT 토큰을 생성하고 요청 헤더에 추가하는 RequestPostProcessor 생성
+     * 
+     * @param jwtService JWT 서비스
+     * @param user 유저 정보
+     * @return JWT 토큰이 포함된 RequestPostProcessor
+     */
+    public static RequestPostProcessor withJwt(JwtService jwtService, User user) {
+        return mockRequest -> {
+            // 토큰 생성 및 Authorization 헤더에 추가
+            String token = jwtService.createAccessToken(user.getId());
+            mockRequest.addHeader("Authorization", "Bearer " + token);
+
+            // SecurityContext에 인증 정보 설정
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            Authentication auth = new JwtAuthentication(user,
+                    user.isAdmin() ? AuthorityUtils.createAuthorityList("ROLE_ADMIN")
+                            : AuthorityUtils.createAuthorityList("ROLE_USER"));
+            context.setAuthentication(auth);
+            SecurityContextHolder.setContext(context);
+
+            // 테스트용 특별 헤더 추가
+            mockRequest.addHeader("X-Test-User-Id", user.getId().toString());
+            mockRequest.addHeader("X-Test-Auth", "true");
+
+            return mockRequest;
+        };
+    }
+
+    /**
+     * 가짜 JWT 토큰을 생성하여 요청 헤더에 추가하는 RequestPostProcessor 생성 JwtService가 모킹되어 있을 때 사용
+     * 
+     * @return 가짜 JWT 토큰이 포함된 RequestPostProcessor
+     */
+    public static RequestPostProcessor withMockJwt() {
+        return mockRequest -> {
+            mockRequest.addHeader("Authorization", "Bearer mock-jwt-token");
+            return mockRequest;
+        };
+    }
+}

--- a/src/test/java/com/server/domain/user/controller/TestConfig.java
+++ b/src/test/java/com/server/domain/user/controller/TestConfig.java
@@ -1,0 +1,10 @@
+package com.server.domain.user.controller;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EntityScan("com.server")
+public class TestConfig {
+    // This class enables JPA entity scanning for our tests
+}

--- a/src/test/java/com/server/domain/user/controller/TestJpaConfig.java
+++ b/src/test/java/com/server/domain/user/controller/TestJpaConfig.java
@@ -1,0 +1,13 @@
+package com.server.domain.user.controller;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@TestConfiguration
+@EntityScan(basePackages = "com.server.domain")
+@EnableJpaRepositories(basePackages = "com.server.domain")
+public class TestJpaConfig {
+    // This configuration ensures that JPA entities are properly scanned in tests
+}

--- a/src/test/java/com/server/domain/user/controller/TestJwtAuthenticationFilter.java
+++ b/src/test/java/com/server/domain/user/controller/TestJwtAuthenticationFilter.java
@@ -1,0 +1,72 @@
+package com.server.domain.user.controller;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.server.domain.user.entity.User;
+import com.server.global.jwt.JwtAuthentication;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Test-specific JWT authentication filter that creates authentication based on Authorization header
+ */
+@Slf4j
+public class TestJwtAuthenticationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        String authHeader = request.getHeader("Authorization");
+        List<GrantedAuthority> authorities = new ArrayList<>();
+
+        // If security context already has authentication (from the RequestPostProcessor), use that
+        Authentication existingAuth = SecurityContextHolder.getContext().getAuthentication();
+        if (existingAuth != null && existingAuth.isAuthenticated()) {
+            log.info("Using existing authentication: {}", existingAuth.getName());
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // Otherwise, check if the Authorization header contains a JWT token
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            log.info("Found Bearer token in header: {}", authHeader);
+
+            // For tests, we don't validate the token - just having it is enough
+            // Instead, we create a mock User and authorities
+            User mockUser = new User();
+            mockUser.setId(1L);
+            mockUser.setNickname("testUser");
+            mockUser.setAdmin(false);
+
+            // Assign USER role by default
+            authorities = AuthorityUtils.createAuthorityList("ROLE_USER");
+
+            // Create and set authentication
+            Authentication auth = new JwtAuthentication(mockUser, authorities);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+
+            log.info("Set up test authentication for user: {}", mockUser.getNickname());
+        } else {
+            log.info("No Authorization header found or not a Bearer token");
+            // Set anonymous role if no Authorization header
+            authorities = AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS");
+            SecurityContextHolder.getContext()
+                    .setAuthentication(new JwtAuthentication(null, authorities));
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/test/java/com/server/domain/user/controller/TestSecurityConfig.java
+++ b/src/test/java/com/server/domain/user/controller/TestSecurityConfig.java
@@ -1,0 +1,98 @@
+package com.server.domain.user.controller;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Arrays;
+import java.util.List;
+
+@TestConfiguration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class TestSecurityConfig implements WebMvcConfigurer {
+
+    @Bean
+    @Primary
+    public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll()).sessionManagement(
+                        session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+
+    @Bean
+    @Primary
+    public UserDetailsService userDetailsService() {
+        return new UserDetailsService() {
+            @Override
+            public UserDetails loadUserByUsername(String username)
+                    throws UsernameNotFoundException {
+                if ("testUser".equals(username)) {
+                    return User.withUsername("testUser").password("password")
+                            .authorities(Arrays.asList(new SimpleGrantedAuthority("ROLE_USER")))
+                            .build();
+                }
+                throw new UsernameNotFoundException("User not found: " + username);
+            }
+        };
+    }
+
+    /**
+     * AuthenticationPrincipal 어노테이션 처리를 위한 ArgumentResolver를 등록
+     */
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new TestUserArgumentResolver());
+    }
+
+    /**
+     * 테스트용 AuthenticationPrincipal 어노테이션 처리기
+     */
+    static class TestUserArgumentResolver implements HandlerMethodArgumentResolver {
+        @Override
+        public boolean supportsParameter(MethodParameter parameter) {
+            return parameter.getParameterType().equals(com.server.domain.user.entity.User.class)
+                    && parameter.hasParameterAnnotation(
+                            org.springframework.security.core.annotation.AuthenticationPrincipal.class);
+        }
+
+        @Override
+        public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth != null && auth.getPrincipal() instanceof com.server.domain.user.entity.User) {
+                return auth.getPrincipal();
+            }
+
+            // 기본 테스트 사용자 생성
+            com.server.domain.user.entity.User testUser = new com.server.domain.user.entity.User();
+            testUser.setId(1L);
+            testUser.setNickname("testUser");
+            testUser.setThumbnail("thumbnail.jpg");
+            testUser.setCode("USER123");
+            testUser.setAdmin(false);
+
+            return testUser;
+        }
+    }
+}

--- a/src/test/java/com/server/domain/user/controller/TestUserPrincipal.java
+++ b/src/test/java/com/server/domain/user/controller/TestUserPrincipal.java
@@ -1,0 +1,58 @@
+package com.server.domain.user.controller;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.server.domain.user.entity.User;
+
+public class TestUserPrincipal implements UserDetails {
+
+    private final User user;
+
+    public TestUserPrincipal(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return "password";
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getNickname();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public User getUser() {
+        return user;
+    }
+}

--- a/src/test/java/com/server/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/server/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,171 @@
+package com.server.domain.user.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.server.domain.user.dto.RegisterUserInDto;
+import com.server.domain.user.dto.RestoreAccountDto;
+import com.server.domain.user.dto.UserDto;
+import com.server.domain.user.entity.User;
+import com.server.domain.user.service.UserService;
+import com.server.global.jwt.JwtAuthentication;
+import com.server.global.jwt.JwtService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import({TestSecurityConfig.class, TestJpaConfig.class})
+public class UserControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    private User mockUser;
+    private UserDto mockUserDto;
+
+    @BeforeEach
+    void setUp() {
+        // 각 테스트 전에 MockMvc를 재설정
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+
+        // Setup mock User
+        mockUser = new User();
+        mockUser.setId(1L);
+        mockUser.setNickname("testUser");
+        mockUser.setThumbnail("thumbnail.jpg");
+        mockUser.setCode("USER123");
+        mockUser.setAdmin(false);
+
+        // Setup mock UserDto
+        mockUserDto = UserDto.builder().nickname("testUser").thumbnail("thumbnail.jpg")
+                .code("USER123").isRegistered(true).restoreEnabled(false).build();
+
+        // Setup userService to return mockUser
+        when(userService.getUserWithPersonalInfo(any(Long.class))).thenReturn(mockUser);
+
+        // Setup JWT service to return a valid token for any user ID
+        when(jwtService.createAccessToken(anyLong())).thenReturn("mock-jwt-token");
+
+        // 기본 인증 설정
+        Authentication auth =
+                new JwtAuthentication(mockUser, AuthorityUtils.createAuthorityList("ROLE_USER"));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @Test
+    @DisplayName("Get user information test")
+    void getUserTest() throws Exception {
+        // Setup mock userService behavior
+        when(userService.getUser(any(User.class))).thenReturn(mockUserDto);
+
+        // Execute request with JWT authentication and verify response
+        mockMvc.perform(get("/api/users/me").with(JwtTestUtil.withJwt(jwtService, mockUser)))
+                .andDo(print()).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Delete user (soft delete) test")
+    void deleteUserTest() throws Exception {
+        // Setup mock userService behavior
+        when(userService.deleteUser(any(User.class), anyBoolean())).thenReturn("testUser");
+
+        // Execute request with JWT authentication and verify response
+        mockMvc.perform(delete("/api/users/me").with(JwtTestUtil.withJwt(jwtService, mockUser)))
+                .andDo(print()).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Register user test")
+    void registerUserTest() throws Exception {
+        // Setup mock data
+        Map<Long, Boolean> termAgreements = new HashMap<>();
+        termAgreements.put(1L, true);
+        termAgreements.put(2L, false);
+
+        RegisterUserInDto registerUserInDto = new RegisterUserInDto();
+        registerUserInDto.setTermAgreements(termAgreements);
+
+        // Setup mock userService behavior
+        when(userService.registerUser(any(User.class), anyMap())).thenReturn("testUser");
+
+        // Execute request with JWT authentication and verify response
+        mockMvc.perform(post("/api/users/me").with(JwtTestUtil.withJwt(jwtService, mockUser))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerUserInDto))).andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Restore account test")
+    void restoreAccountTest() throws Exception {
+        // Setup mock data
+        RestoreAccountDto restoreAccountDto = new RestoreAccountDto(true);
+
+        // Setup mock userService behavior
+        when(userService.restoreAccount(anyLong())).thenReturn("testUser");
+
+        // Execute request with JWT authentication and verify response
+        mockMvc.perform(post("/api/users/restore").with(JwtTestUtil.withJwt(jwtService, mockUser))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(restoreAccountDto))).andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Delete account (hard delete) test")
+    void deleteAccountTest() throws Exception {
+        // Setup mock data
+        RestoreAccountDto restoreAccountDto = new RestoreAccountDto(false);
+
+        // Setup mock userService behavior
+        when(userService.deleteUser(any(User.class), anyBoolean())).thenReturn("testUser");
+
+        // Execute request with JWT authentication and verify response
+        mockMvc.perform(post("/api/users/restore").with(JwtTestUtil.withJwt(jwtService, mockUser))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(restoreAccountDto))).andDo(print())
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/server/domain/user/controller/UserControllerTestConfig.java
+++ b/src/test/java/com/server/domain/user/controller/UserControllerTestConfig.java
@@ -1,0 +1,30 @@
+package com.server.domain.user.controller;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+
+@TestConfiguration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class UserControllerTestConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+            HandlerMappingIntrospector introspector) throws Exception {
+        MvcRequestMatcher.Builder mvcMatcherBuilder = new MvcRequestMatcher.Builder(introspector);
+
+        http.csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(mvcMatcherBuilder.pattern("/api/users/**")).permitAll()
+                        .anyRequest().permitAll());
+
+        return http.build();
+    }
+}

--- a/src/test/java/com/server/domain/user/service/CoupleServiceTest.java
+++ b/src/test/java/com/server/domain/user/service/CoupleServiceTest.java
@@ -1,0 +1,248 @@
+package com.server.domain.user.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.server.domain.term.entity.Term;
+import com.server.domain.user.dto.CoupleDto;
+import com.server.domain.user.entity.Couple;
+import com.server.domain.user.entity.User;
+import com.server.domain.user.repository.CoupleRepository;
+import com.server.domain.user.repository.UserRepository;
+import com.server.global.error.code.CoupleErrorCode;
+import com.server.global.error.exception.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+public class CoupleServiceTest {
+
+    @Mock
+    private CoupleRepository coupleRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private CoupleService coupleService;
+
+    private User user1;
+    private User user2;
+    private Couple couple;
+    private LocalDate firstMetDate;
+    private LocalDateTime createdDateTime;
+
+    @BeforeEach
+    void setUp() {
+        // Create empty terms list to avoid NullPointerException
+        ArrayList<Term> emptyTerms = new ArrayList<>();
+
+        // Setup users
+        user1 = User.builder().nickname("User1").thumbnail("user1_thumbnail.jpg").code("USER1_CODE")
+                .terms(emptyTerms) // Add empty terms list instead of null
+                .build();
+        user1.setId(1L);
+
+        user2 = User.builder().nickname("User2").thumbnail("user2_thumbnail.jpg").code("USER2_CODE")
+                .terms(emptyTerms) // Add empty terms list instead of null
+                .build();
+        user2.setId(2L);
+
+        // Setup dates
+        firstMetDate = LocalDate.of(2025, 1, 1);
+        createdDateTime = LocalDateTime.of(2025, 4, 29, 12, 0);
+
+        // Setup couple
+        couple = Couple.builder().user1(user1).user2(user2).firstMetDate(firstMetDate).build();
+        couple.setId(1L);
+        couple.setCreatedAt(createdDateTime);
+        couple.setUpdatedAt(createdDateTime);
+    }
+
+    @Test
+    @DisplayName("Connect couple - successful connection")
+    void connectCoupleSuccessTest() {
+        // Setup
+        when(userRepository.findByCode("USER2_CODE")).thenReturn(Optional.of(user2));
+
+        // Mock the save method to set created date before returning
+        when(coupleRepository.save(any(Couple.class))).thenAnswer(invocation -> {
+            Couple savedCouple = invocation.getArgument(0);
+            if (savedCouple.getCreatedAt() == null) {
+                savedCouple.setCreatedAt(createdDateTime);
+            }
+            savedCouple.setId(1L);
+            return savedCouple;
+        });
+
+        // Call the method
+        CoupleDto result = coupleService.connectCouple(user1, "USER2_CODE");
+
+        // Verify
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals("User2", result.getPartnerNickname());
+        assertEquals("user2_thumbnail.jpg", result.getPartnerThumbnail());
+        verify(coupleRepository).save(any(Couple.class));
+    }
+
+    @Test
+    @DisplayName("Connect couple - user already connected")
+    void connectCoupleUserAlreadyConnectedTest() {
+        // Setup
+        user1.setCoupleAsUser1(couple); // Set user as already connected
+
+        // Call and verify
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            coupleService.connectCouple(user1, "USER2_CODE");
+        });
+
+        assertEquals(CoupleErrorCode.ALREADY_CONNECTED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("Connect couple - partner not found")
+    void connectCouplePartnerNotFoundTest() {
+        // Setup
+        when(userRepository.findByCode("NONEXISTENT_CODE")).thenReturn(Optional.empty());
+
+        // Call and verify
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            coupleService.connectCouple(user1, "NONEXISTENT_CODE");
+        });
+
+        assertEquals(CoupleErrorCode.PARTNER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("Connect couple - self connection attempt")
+    void connectCoupleSelfConnectionTest() {
+        // Setup
+        when(userRepository.findByCode("USER1_CODE")).thenReturn(Optional.of(user1));
+
+        // Call and verify
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            coupleService.connectCouple(user1, "USER1_CODE");
+        });
+
+        assertEquals(CoupleErrorCode.SELF_CONNECTION_NOT_ALLOWED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("Connect couple - partner already connected")
+    void connectCouplePartnerAlreadyConnectedTest() {
+        // Setup
+        user2.setCoupleAsUser2(couple); // Set partner as already connected
+        when(userRepository.findByCode("USER2_CODE")).thenReturn(Optional.of(user2));
+
+        // Call and verify
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            coupleService.connectCouple(user1, "USER2_CODE");
+        });
+
+        assertEquals(CoupleErrorCode.PARTNER_ALREADY_CONNECTED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("Get couple - successful retrieval")
+    void getCoupleSuccessTest() {
+        // Setup
+        when(coupleRepository.findByUser1OrUser2(user1, user1)).thenReturn(Optional.of(couple));
+
+        // Call the method
+        CoupleDto result = coupleService.getCouple(user1);
+
+        // Verify
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals("User2", result.getPartnerNickname());
+        assertEquals("user2_thumbnail.jpg", result.getPartnerThumbnail());
+        assertEquals(firstMetDate, result.getFirstMetDate());
+    }
+
+    @Test
+    @DisplayName("Get couple - not found")
+    void getCoupleNotFoundTest() {
+        // Setup
+        when(coupleRepository.findByUser1OrUser2(user1, user1)).thenReturn(Optional.empty());
+
+        // Call and verify
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            coupleService.getCouple(user1);
+        });
+
+        assertEquals(CoupleErrorCode.COUPLE_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("Disconnect couple - successful disconnection")
+    void disconnectCoupleSuccessTest() {
+        // Setup
+        when(coupleRepository.findByUser1OrUser2(user1, user1)).thenReturn(Optional.of(couple));
+
+        // Call the method
+        Long result = coupleService.disconnectCouple(user1);
+
+        // Verify
+        assertEquals(1L, result);
+        verify(coupleRepository).delete(couple);
+    }
+
+    @Test
+    @DisplayName("Disconnect couple - not found")
+    void disconnectCoupleNotFoundTest() {
+        // Setup
+        when(coupleRepository.findByUser1OrUser2(user1, user1)).thenReturn(Optional.empty());
+
+        // Call and verify
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            coupleService.disconnectCouple(user1);
+        });
+
+        assertEquals(CoupleErrorCode.COUPLE_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("Update first met date - successful update")
+    void updateFirstMetDateSuccessTest() {
+        // Setup
+        LocalDate newDate = LocalDate.of(2024, 12, 25);
+        when(coupleRepository.findByUser1OrUser2(user1, user1)).thenReturn(Optional.of(couple));
+        when(coupleRepository.save(couple)).thenReturn(couple);
+
+        // Call the method
+        CoupleDto result = coupleService.updateFirstMetDate(user1, newDate);
+
+        // Verify
+        assertNotNull(result);
+        assertEquals(newDate, couple.getFirstMetDate());
+        verify(coupleRepository).save(couple);
+    }
+
+    @Test
+    @DisplayName("Update first met date - couple not found")
+    void updateFirstMetDateNotFoundTest() {
+        // Setup
+        LocalDate newDate = LocalDate.of(2024, 12, 25);
+        when(coupleRepository.findByUser1OrUser2(user1, user1)).thenReturn(Optional.empty());
+
+        // Call and verify
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            coupleService.updateFirstMetDate(user1, newDate);
+        });
+
+        assertEquals(CoupleErrorCode.COUPLE_NOT_FOUND, exception.getErrorCode());
+    }
+}


### PR DESCRIPTION
## 관련 이슈
Resolves #61 - Test: 현재 9%인 테스트 코드 커버리지 개선 필요

## 변경 사항
- 섹션 도메인에 대한 종합적인 테스트 케이스 추가:
  - `SectionControllerTest` 생성:
    - 홈 섹션 조회 테스트
    - 섹션 생성 테스트
  - `SectionServiceTest` 생성:
    - 홈 섹션 조회 테스트
    - 섹션 생성 테스트
    - 존재하지 않는 카테고리로 섹션 생성 시 예외 발생 테스트
    - 장소 타입과 코스 타입에 대한 DTO 변환 테스트
    - 빈 섹션 리스트와 같은 엣지 케이스 테스트
- 한글 텍스트 처리를 위한 인코딩 이슈 수정

## 테스트 커버리지
이 PR은 애플리케이션 전체의 테스트 커버리지를 체계적으로 개선하기 위한 지속적인 노력의 일환입니다.
이전에 테스트한 도메인:
- 유저 도메인
- 약관 도메인
- 카테고리 도메인
- 커플 도메인
- 이벤트 도메인

## 테스트 방법
다음 명령으로 테스트 스위트를 실행하세요:
```bash
./gradlew test
```

## 추가 정보
- 한글 문자를 처리하는 테스트에서 인코딩 이슈 수정
- 섹션 도메인의 정상 작동 및 오류 케이스 검증
- 의존성 모킹과 테스트 설정을 위한 ReflectionTestUtils 사용