### PR TITLE
feat: 사용자 등록 시 닉네임 입력 기능 추가

### DIFF
--- a/src/main/java/com/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/domain/user/controller/UserController.java
@@ -55,12 +55,13 @@ public class UserController {
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/me")
-    @Operation(summary = "유저 등록", description = "유저 약관 동의 업데이트")
+    @Operation(summary = "유저 등록", description = "유저 약관 동의 및 닉네임 업데이트")
     public ApiResponseDto<String> registerUser(@AuthenticationPrincipal User user,
             @RequestBody RegisterUserInDto body) {
-        String nickname = userService.registerUser(user, body.getTermAgreements());
+        String nickname =
+                userService.registerUser(user, body.getTermAgreements(), body.getNickname());
         return ApiResponseDto.success(HttpStatus.OK.value(),
-                String.format("User %s term agreements updated successfully", nickname));
+                String.format("User %s information updated successfully", nickname));
     }
 
     // 계정 관리 (복구 또는 삭제)

--- a/src/main/java/com/server/domain/user/dto/RegisterUserInDto.java
+++ b/src/main/java/com/server/domain/user/dto/RegisterUserInDto.java
@@ -11,4 +11,5 @@ import lombok.Setter;
 @NoArgsConstructor
 public class RegisterUserInDto {
     private Map<Long, Boolean> termAgreements; // Key: Term ID, Value: Agreed or not
+    private String nickname; // 사용자 닉네임
 }

--- a/src/main/java/com/server/domain/user/service/UserService.java
+++ b/src/main/java/com/server/domain/user/service/UserService.java
@@ -75,7 +75,7 @@ public class UserService {
     }
 
     @Transactional
-    public String registerUser(User user, Map<Long, Boolean> termAgreements) {
+    public String registerUser(User user, Map<Long, Boolean> termAgreements, String nickname) {
         if (user == null) {
             throw new BusinessException(UserErrorCode.NOT_FOUND);
         }
@@ -83,6 +83,12 @@ public class UserService {
         if (termAgreements == null || termAgreements.isEmpty()) {
             log.error("Term agreements map is empty or null");
             throw new BusinessException(UserErrorCode.INVALID_PARAMETER);
+        }
+
+        // 닉네임 설정 (제공된 경우)
+        if (nickname != null && !nickname.trim().isEmpty()) {
+            user.setNickname(nickname);
+            log.debug("Updated nickname for user ID {}: {}", user.getId(), nickname);
         }
 
         // Update each term agreement based on the provided term ID and boolean value
@@ -106,8 +112,13 @@ public class UserService {
         }
 
         userRepository.save(user);
-        log.info("Updated term agreements for user: {}", user.getNickname());
+        log.info("Updated user information and term agreements for user: {}", user.getNickname());
         return user.getNickname();
+    }
+
+    @Transactional
+    public String registerUser(User user, Map<Long, Boolean> termAgreements) {
+        return registerUser(user, termAgreements, null);
     }
 
     @Transactional

--- a/src/test/java/com/server/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/server/domain/user/service/UserServiceTest.java
@@ -249,4 +249,62 @@ public class UserServiceTest {
         assertEquals("newRefreshToken", user.getRefreshToken());
         verify(userRepository).save(user);
     }
+
+    @Test
+    @DisplayName("Register user test with nickname update")
+    void registerUserWithNicknameTest() {
+        // Setup
+        Map<Long, Boolean> termAgreements = new HashMap<>();
+        termAgreements.put(1L, true); // Required term
+        termAgreements.put(2L, false); // Optional term
+        String newNickname = "newNickname";
+
+        // Call the method
+        String result = userService.registerUser(user, termAgreements, newNickname);
+
+        // Verify the results
+        assertEquals(newNickname, result);
+        assertEquals(newNickname, user.getNickname());
+        verify(termAgreementRepository, times(2)).save(any(TermAgreement.class));
+        verify(userRepository).save(user);
+
+        // Verify term agreements were updated
+        assertTrue(user.getTermAgreements().get(0).isAgreed());
+        assertFalse(user.getTermAgreements().get(1).isAgreed());
+    }
+
+    @Test
+    @DisplayName("Register user test with empty nickname")
+    void registerUserWithEmptyNicknameTest() {
+        // Setup
+        Map<Long, Boolean> termAgreements = new HashMap<>();
+        termAgreements.put(1L, true); // Required term
+        String originalNickname = user.getNickname();
+        String emptyNickname = "   ";
+
+        // Call the method
+        String result = userService.registerUser(user, termAgreements, emptyNickname);
+
+        // Verify that the nickname remains unchanged
+        assertEquals(originalNickname, result);
+        assertEquals(originalNickname, user.getNickname());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    @DisplayName("Register user test with null nickname")
+    void registerUserWithNullNicknameTest() {
+        // Setup
+        Map<Long, Boolean> termAgreements = new HashMap<>();
+        termAgreements.put(1L, true); // Required term
+        String originalNickname = user.getNickname();
+
+        // Call the method
+        String result = userService.registerUser(user, termAgreements, null);
+
+        // Verify that the nickname remains unchanged
+        assertEquals(originalNickname, result);
+        assertEquals(originalNickname, user.getNickname());
+        verify(userRepository).save(user);
+    }
 }


### PR DESCRIPTION
## 변경 내용
- RegisterUserInDto 클래스에 nickname 필드 추가
- UserService에 닉네임 매개변수를 포함하는 새로운 registerUser 메서드 추가
- 기존 registerUser 메서드는 새 메서드를 호출하도록 수정
- UserController의 registerUser 메서드 수정하여 닉네임 처리 추가
- 테스트 코드 추가: 닉네임 설정 기능에 대한 각종 테스트 케이스 구현

## 관련 이슈
- Closes #41

## 테스트 수행 여부
- [X] 단위 테스트 추가 및 통과
- [X] 기능 테스트 수행