### PR TITLE
Feat: Standardize all error messages to English (Issue #78)

### DIFF
--- a/src/main/java/com/server/global/error/code/AuthErrorCode.java
+++ b/src/main/java/com/server/global/error/code/AuthErrorCode.java
@@ -8,11 +8,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
-    URL_NOT_PERMITTED(HttpStatus.FORBIDDEN.value(), "허용되지 않은 URL입니다."),
-    OAUTH_PROCESS_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "OAuth 과정 중 오류가 발생했습니다."),
-    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 access token입니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 refresh token입니다."),
-    ILLEGAL_REGISTRATION_ID(HttpStatus.INTERNAL_SERVER_ERROR.value(), "잘못된 registration id입니다.");
+    URL_NOT_PERMITTED(HttpStatus.FORBIDDEN.value(), "URL not permitted."),
+    OAUTH_PROCESS_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Error during OAuth process."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED.value(), "Invalid access token."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(), "Invalid refresh token."),
+    ILLEGAL_REGISTRATION_ID(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Invalid registration ID.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/server/global/error/code/CategoryErrorCode.java
+++ b/src/main/java/com/server/global/error/code/CategoryErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum CategoryErrorCode implements ErrorCode {
-    NOT_FOUND(HttpStatus.NOT_FOUND.value(), "카테고리가 존재하지 않습니다.");
+    NOT_FOUND(HttpStatus.NOT_FOUND.value(), "Category not found.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/server/global/error/code/CoupleErrorCode.java
+++ b/src/main/java/com/server/global/error/code/CoupleErrorCode.java
@@ -9,13 +9,13 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum CoupleErrorCode implements ErrorCode {
 
-    ALREADY_CONNECTED(HttpStatus.BAD_REQUEST.value(), "이미 커플로 연결된 사용자입니다."), PARTNER_NOT_FOUND(
+    ALREADY_CONNECTED(HttpStatus.BAD_REQUEST.value(), "User is already connected as a couple."), PARTNER_NOT_FOUND(
             HttpStatus.NOT_FOUND.value(),
-            "해당 코드를 가진 사용자를 찾을 수 없습니다."), PARTNER_ALREADY_CONNECTED(HttpStatus.BAD_REQUEST.value(),
-                    "상대방이 이미 커플로 연결된 사용자입니다."), SELF_CONNECTION_NOT_ALLOWED(
+            "User with the provided code not found."), PARTNER_ALREADY_CONNECTED(HttpStatus.BAD_REQUEST.value(),
+                    "The partner is already connected as a couple."), SELF_CONNECTION_NOT_ALLOWED(
                             HttpStatus.BAD_REQUEST.value(),
-                            "자기 자신과 커플 연결을 할 수 없습니다."), COUPLE_NOT_FOUND(
-                                    HttpStatus.NOT_FOUND.value(), "연결된 커플을 찾을 수 없습니다.");
+                            "Cannot connect with oneself as a couple."), COUPLE_NOT_FOUND(
+                                    HttpStatus.NOT_FOUND.value(), "Connected couple not found.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/server/global/error/code/EventErrorCode.java
+++ b/src/main/java/com/server/global/error/code/EventErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum EventErrorCode implements ErrorCode {
-    NOT_FOUND(HttpStatus.NOT_FOUND.value(), "이벤트 정보가 존재하지 않습니다.");
+    NOT_FOUND(HttpStatus.NOT_FOUND.value(), "Event information not found.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/server/global/error/code/FriendErrorCode.java
+++ b/src/main/java/com/server/global/error/code/FriendErrorCode.java
@@ -8,13 +8,13 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum FriendErrorCode implements ErrorCode {
-    FRIENDS_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), "이미 친구 상태입니다."),
-    REQUEST_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), "친구 신청을 이미 완료했습니다."),
-    REQUEST_ALREADY_REMOVED(HttpStatus.GONE.value(), "이미 삭제된 친구 신청입니다."),
-    REQUEST_ALREADY_REJECTED(HttpStatus.GONE.value(), "거절당한 친구 신청입니다."),
-    RECEIPT_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), "해당 사용자에게서 이미 친구 신청을 받은 상태입니다."),
-    SELF_FRIEND_REQUEST_NOT_ALLOWED(HttpStatus.BAD_REQUEST.value(), "자기 자신을 친구로 추가할 수 없습니다."),
-    REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "친구 신청이 존재하지 않습니다.");
+    FRIENDS_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), "Already friends."),
+    REQUEST_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), "Friend request already sent."),
+    REQUEST_ALREADY_REMOVED(HttpStatus.GONE.value(), "Friend request already removed."),
+    REQUEST_ALREADY_REJECTED(HttpStatus.GONE.value(), "Friend request already rejected."),
+    RECEIPT_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), "Friend request already received from this user."),
+    SELF_FRIEND_REQUEST_NOT_ALLOWED(HttpStatus.BAD_REQUEST.value(), "Cannot send friend request to oneself."),
+    REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "Friend request not found.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/server/global/error/code/MapErrorCode.java
+++ b/src/main/java/com/server/global/error/code/MapErrorCode.java
@@ -9,9 +9,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MapErrorCode implements ErrorCode {
 
-    API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Map API 호출 중 오류가 발생했습니다."), INVALID_PARAMETER(
-            HttpStatus.BAD_REQUEST, "유효하지 않은 매개변수입니다."), INVALID_COORDINATES(HttpStatus.BAD_REQUEST,
-                    "유효하지 않은 좌표입니다."), INVALID_ADDRESS(HttpStatus.BAD_REQUEST, "유효하지 않은 주소입니다.");
+    API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Error calling Map API."), INVALID_PARAMETER(
+            HttpStatus.BAD_REQUEST, "Invalid parameter."), INVALID_COORDINATES(HttpStatus.BAD_REQUEST,
+                    "Invalid coordinates."), INVALID_ADDRESS(HttpStatus.BAD_REQUEST, "Invalid address.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/server/global/error/code/ProjectErrorCode.java
+++ b/src/main/java/com/server/global/error/code/ProjectErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ProjectErrorCode implements ErrorCode {
-    NOT_FOUND(HttpStatus.NOT_FOUND.value(), "프로젝트가 존재하지 않습니다.");
+    NOT_FOUND(HttpStatus.NOT_FOUND.value(), "Project not found.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/server/global/error/code/TermErrorCode.java
+++ b/src/main/java/com/server/global/error/code/TermErrorCode.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum TermErrorCode implements ErrorCode {
-    REQUIRED_TERM_NOT_AGREED(HttpStatus.BAD_REQUEST.value(), "필수적 동의 항목에 동의하지 않았습니다.");
+    REQUIRED_TERM_NOT_AGREED(HttpStatus.BAD_REQUEST.value(), "Required term not agreed.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/server/global/error/code/UserErrorCode.java
+++ b/src/main/java/com/server/global/error/code/UserErrorCode.java
@@ -8,10 +8,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-    NOT_FOUND(HttpStatus.NOT_FOUND.value(), "사용자가 존재하지 않습니다."), INVALID_PARAMETER(
-            HttpStatus.BAD_REQUEST.value(), "잘못된 요청입니다."), ALREADY_ACTIVE(
-                    HttpStatus.BAD_REQUEST.value(), "이미 활성화된 계정입니다."), RESTORATION_PERIOD_EXPIRED(
-                            HttpStatus.GONE.value(), "계정 복구 기간이 만료되었습니다.");
+    NOT_FOUND(HttpStatus.NOT_FOUND.value(), "User not found."), INVALID_PARAMETER(
+            HttpStatus.BAD_REQUEST.value(), "Invalid parameter."), ALREADY_ACTIVE(
+                    HttpStatus.BAD_REQUEST.value(), "Account is already active."), RESTORATION_PERIOD_EXPIRED(
+                            HttpStatus.GONE.value(), "Account restoration period has expired.");
 
     private final int status;
     private final String message;


### PR DESCRIPTION
Resolves #78.

This PR standardizes all error messages in the `com.server.global.error.code` package to English.

**Files Modified:**
- `AuthErrorCode.java`
- `CategoryErrorCode.java`
- `CoupleErrorCode.java`
- `EventErrorCode.java`
- `FriendErrorCode.java`
- `MapErrorCode.java`
- `ProjectErrorCode.java`
- `TermErrorCode.java`
- `UserErrorCode.java`

All Korean error messages within these files have been translated to English to ensure consistency and improve internationalization.