### PR TITLE
[feat] 공통 이미지 업로드 API 구현 및 CDN URI 표준화 체계 구축

### DIFF
--- a/src/main/java/com/server/domain/course/controller/CourseController.java
+++ b/src/main/java/com/server/domain/course/controller/CourseController.java
@@ -1,6 +1,7 @@
 package com.server.domain.course.controller;
 
 import com.server.domain.course.dto.CourseDetailDto;
+import com.server.domain.course.dto.CourseImageDto;
 import com.server.domain.course.service.CourseService;
 import com.server.domain.user.entity.User;
 import com.server.global.dto.ApiResponseDto;
@@ -8,9 +9,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/courses")
@@ -23,11 +26,44 @@ public class CourseController {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{courseId}")
     @Operation(summary = "코스 정보 가져오기", description = "해당 id 코스 dto 반환")
-    public ApiResponseDto<CourseDetailDto> getCourseDetail(@PathVariable Long courseId){
+    public ApiResponseDto<CourseDetailDto> getCourseDetail(@PathVariable Long courseId) {
         CourseDetailDto courseDetailDto = courseService.getCourseDetail(courseId);
         log.info("Returning API response with CourseDetailDto: {}", courseDetailDto);
 
         return ApiResponseDto.success(HttpStatus.OK.value(), courseDetailDto);
     }
 
+    /**
+     * 코스 이미지 업로드 API
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping(value = "/{courseId}/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "코스 이미지 업로드", description = "코스에 새로운 이미지 업로드")
+    public ApiResponseDto<CourseImageDto> uploadCourseImage(@AuthenticationPrincipal User user,
+            @PathVariable Long courseId, @RequestPart("file") MultipartFile file) {
+
+        log.info("Course image upload requested for course ID: {}, by user: {}", courseId,
+                user.getNickname());
+
+        CourseImageDto courseImageDto = courseService.uploadCourseImage(courseId, file);
+        return ApiResponseDto.success(HttpStatus.OK.value(), courseImageDto);
+    }
+
+    /**
+     * 코스 대표 이미지(썸네일) 업데이트 API
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @ResponseStatus(HttpStatus.OK)
+    @PutMapping(value = "/{courseId}/thumbnail", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "코스 대표 이미지 업데이트", description = "코스의 대표 이미지(썸네일) 업데이트")
+    public ApiResponseDto<CourseDetailDto> updateCourseThumbnail(@AuthenticationPrincipal User user,
+            @PathVariable Long courseId, @RequestPart("file") MultipartFile file) {
+
+        log.info("Course thumbnail update requested for course ID: {}, by user: {}", courseId,
+                user.getNickname());
+
+        CourseDetailDto courseDetailDto = courseService.updateCourseThumbnail(courseId, file);
+        return ApiResponseDto.success(HttpStatus.OK.value(), courseDetailDto);
+    }
 }

--- a/src/main/java/com/server/domain/course/service/CourseService.java
+++ b/src/main/java/com/server/domain/course/service/CourseService.java
@@ -3,17 +3,21 @@ package com.server.domain.course.service;
 import com.server.domain.course.dto.CourseDetailDto;
 import com.server.domain.course.dto.CourseImageDto;
 import com.server.domain.course.entity.Course;
+import com.server.domain.course.entity.CourseImage;
 import com.server.domain.course.repository.CourseBookmarkRepository;
 import com.server.domain.course.repository.CourseRepository;
 import com.server.domain.place.dto.PlaceDetailDto;
 import com.server.domain.place.repository.PlaceRepository;
+import com.server.global.dto.ImageResponseDto;
 import com.server.global.error.code.CourseErrorCode;
 import com.server.global.error.code.PlaceErrorCode;
 import com.server.global.error.exception.BusinessException;
+import com.server.global.service.ImageService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,41 +28,102 @@ import java.util.stream.Collectors;
 @Slf4j
 public class CourseService {
 
-    private final CourseRepository courseRepository;
-    private final CourseBookmarkRepository courseBookmarkRepository;
-    private final PlaceRepository placeRepository;
+        private final CourseRepository courseRepository;
+        private final CourseBookmarkRepository courseBookmarkRepository;
+        private final PlaceRepository placeRepository;
+        private final ImageService imageService;
 
-    @Transactional
-    public CourseDetailDto getCourseDetail(Long courseId) {
-        Course course = courseRepository.findById(courseId)
-                .orElseThrow(() -> new BusinessException(CourseErrorCode.NOT_FOUND));
+        @Transactional
+        public CourseDetailDto getCourseDetail(Long courseId) {
+                Course course = courseRepository.findById(courseId).orElseThrow(
+                                () -> new BusinessException(CourseErrorCode.NOT_FOUND));
 
-        // 연관된 엔티티 로딩
-        course.getCourseImages().size();
-        course.getCoursePlaces().size();
+                // 연관된 엔티티 로딩
+                course.getCourseImages().size();
+                course.getCoursePlaces().size();
 
-        log.info("Course: {}", course);  // Course 객체의 상태 확인
+                log.info("Course: {}", course); // Course 객체의 상태 확인
 
-        List<CourseImageDto> courseImages = course.getCourseImages().stream()
-                .map(CourseImageDto::from)
-                .collect(Collectors.toList());
+                List<CourseImageDto> courseImages = course.getCourseImages().stream()
+                                .map(CourseImageDto::from).collect(Collectors.toList());
 
-        log.info("CourseImages: {}", courseImages);  // CourseImages 리스트 확인
+                log.info("CourseImages: {}", courseImages); // CourseImages 리스트 확인
 
-        List<PlaceDetailDto> placeDetails = course.getCoursePlaces().stream()
-                .map(c -> PlaceDetailDto.from(placeRepository.findById(c.getPlace().getId())
-                        .orElseThrow(() -> new BusinessException(PlaceErrorCode.NOT_FOUND))))
-                .collect(Collectors.toList());
+                List<PlaceDetailDto> placeDetails = course.getCoursePlaces().stream()
+                                .map(c -> PlaceDetailDto.from(placeRepository
+                                                .findById(c.getPlace().getId())
+                                                .orElseThrow(() -> new BusinessException(
+                                                                PlaceErrorCode.NOT_FOUND))))
+                                .collect(Collectors.toList());
 
-        log.info("PlaceDetails: {}", placeDetails);  // PlaceDetails 리스트 확인
+                log.info("PlaceDetails: {}", placeDetails); // PlaceDetails 리스트 확인
 
-        log.info("정보", course.getName(), course.getThumbnail(), courseImages.get(0), placeDetails.get(0));
-        return CourseDetailDto.builder()
-                .name(course.getName())
-                .thumbnail(course.getThumbnail())
-                .courseImageDtos(courseImages)
-                .placeDetailDtos(placeDetails)
-                .build();
-    }
+                log.info("정보", course.getName(), course.getThumbnail(), courseImages.get(0),
+                                placeDetails.get(0));
+                return CourseDetailDto.builder().name(course.getName())
+                                .thumbnail(course.getThumbnail()).courseImageDtos(courseImages)
+                                .placeDetailDtos(placeDetails).build();
+        }
 
+        /**
+         * 코스 이미지 업로드
+         * 
+         * @param courseId 코스 ID
+         * @param file 업로드할 이미지 파일
+         * @return 업로드된 이미지 정보
+         */
+        @Transactional
+        public CourseImageDto uploadCourseImage(Long courseId, MultipartFile file) {
+                Course course = courseRepository.findById(courseId).orElseThrow(
+                                () -> new BusinessException(CourseErrorCode.NOT_FOUND));
+
+                // 공통 이미지 서비스를 사용하여 이미지 업로드
+                ImageResponseDto imageResponseDto =
+                                imageService.uploadImage(file, "course", courseId);
+
+                // 코스 이미지 엔티티 생성 및 저장
+                CourseImage courseImage = new CourseImage();
+                courseImage.setImageUrl(imageResponseDto.getImageUrl());
+                courseImage.setCourse(course);
+
+                course.getCourseImages().add(courseImage);
+                courseRepository.save(course);
+
+                log.info("Course image uploaded for course ID {}: {}", courseId,
+                                imageResponseDto.getImageUrl());
+
+                return CourseImageDto.builder().imageUrl(courseImage.getImageUrl()).build();
+        }
+
+        /**
+         * 코스 대표 이미지(썸네일) 업데이트
+         * 
+         * @param courseId 코스 ID
+         * @param file 업로드할 이미지 파일
+         * @return 업데이트된 코스 정보
+         */
+        @Transactional
+        public CourseDetailDto updateCourseThumbnail(Long courseId, MultipartFile file) {
+                Course course = courseRepository.findById(courseId).orElseThrow(
+                                () -> new BusinessException(CourseErrorCode.NOT_FOUND));
+
+                // 기존 썸네일 이미지가 있으면 삭제
+                String oldThumbnail = course.getThumbnail();
+                if (oldThumbnail != null && !oldThumbnail.isEmpty()) {
+                        imageService.deleteImage(oldThumbnail);
+                }
+
+                // 새 이미지 업로드
+                ImageResponseDto imageResponseDto =
+                                imageService.uploadImage(file, "course", courseId);
+
+                // 코스 썸네일 업데이트
+                course.setThumbnail(imageResponseDto.getImageUrl());
+                courseRepository.save(course);
+
+                log.info("Course thumbnail updated for course ID {}: {}", courseId,
+                                imageResponseDto.getImageUrl());
+
+                return getCourseDetail(courseId);
+        }
 }

--- a/src/main/java/com/server/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/server/domain/place/controller/PlaceController.java
@@ -1,14 +1,19 @@
 package com.server.domain.place.controller;
 
 import com.server.domain.place.dto.PlaceDetailDto;
+import com.server.domain.place.dto.PlaceImageDto;
 import com.server.domain.place.service.PlaceService;
+import com.server.domain.user.entity.User;
 import com.server.global.dto.ApiResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,8 +26,42 @@ public class PlaceController {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{placeId}")
     @Operation(summary = "장소 상세 정보", description = "해당 id 장소 상제 정보 PlaceDetailDto 반환")
-    public ApiResponseDto<PlaceDetailDto> getPlaceDetail(@PathVariable Long placeId){
+    public ApiResponseDto<PlaceDetailDto> getPlaceDetail(@PathVariable Long placeId) {
         PlaceDetailDto placeDetailDto = placeService.getPlaceDetail(placeId);
+        return ApiResponseDto.success(HttpStatus.OK.value(), placeDetailDto);
+    }
+
+    /**
+     * 장소 이미지 업로드 API
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping(value = "/{placeId}/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "장소 이미지 업로드", description = "장소에 새로운 이미지 업로드")
+    public ApiResponseDto<PlaceImageDto> uploadPlaceImage(@AuthenticationPrincipal User user,
+            @PathVariable Long placeId, @RequestPart("file") MultipartFile file) {
+
+        log.info("Place image upload requested for place ID: {}, by user: {}", placeId,
+                user.getNickname());
+
+        PlaceImageDto placeImageDto = placeService.uploadPlaceImage(placeId, file);
+        return ApiResponseDto.success(HttpStatus.OK.value(), placeImageDto);
+    }
+
+    /**
+     * 장소 대표 이미지(썸네일) 업데이트 API
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @ResponseStatus(HttpStatus.OK)
+    @PutMapping(value = "/{placeId}/thumbnail", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "장소 대표 이미지 업데이트", description = "장소의 대표 이미지(썸네일) 업데이트")
+    public ApiResponseDto<PlaceDetailDto> updatePlaceThumbnail(@AuthenticationPrincipal User user,
+            @PathVariable Long placeId, @RequestPart("file") MultipartFile file) {
+
+        log.info("Place thumbnail update requested for place ID: {}, by user: {}", placeId,
+                user.getNickname());
+
+        PlaceDetailDto placeDetailDto = placeService.updatePlaceThumbnail(placeId, file);
         return ApiResponseDto.success(HttpStatus.OK.value(), placeDetailDto);
     }
 }

--- a/src/main/java/com/server/domain/place/service/PlaceService.java
+++ b/src/main/java/com/server/domain/place/service/PlaceService.java
@@ -3,14 +3,17 @@ package com.server.domain.place.service;
 import com.server.domain.place.dto.PlaceDetailDto;
 import com.server.domain.place.dto.PlaceImageDto;
 import com.server.domain.place.entity.Place;
+import com.server.domain.place.entity.PlaceImage;
 import com.server.domain.place.repository.PlaceRepository;
-import com.server.global.error.code.AuthErrorCode;
-import com.server.global.error.code.ErrorCode;
+import com.server.global.dto.ImageResponseDto;
 import com.server.global.error.code.PlaceErrorCode;
 import com.server.global.error.exception.BusinessException;
+import com.server.global.service.ImageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.stream.Collectors;
 
@@ -18,22 +21,81 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Slf4j
 public class PlaceService {
-    private final PlaceRepository placeRepository;
+        private final PlaceRepository placeRepository;
+        private final ImageService imageService;
 
-    public PlaceDetailDto getPlaceDetail(Long placeId) {
-        Place place = placeRepository.findById(placeId)
-                .orElseThrow(()-> new BusinessException(PlaceErrorCode.NOT_FOUND));
-        return PlaceDetailDto.builder()
-                .name(place.getName())
-                .address(place.getAddress())
-                .latitude(place.getLatitude())
-                .longitude(place.getLongitude())
-                .categoryName(place.getCategory().getName())
-                .score(place.getScore())
-                .placeImageDtos(place.getPlaceImages().stream()
-                        .map(PlaceImageDto::from)
-                        .collect(Collectors.toList()))
-                .build();
+        public PlaceDetailDto getPlaceDetail(Long placeId) {
+                Place place = placeRepository.findById(placeId)
+                                .orElseThrow(() -> new BusinessException(PlaceErrorCode.NOT_FOUND));
+                return PlaceDetailDto.builder().name(place.getName()).address(place.getAddress())
+                                .latitude(place.getLatitude()).longitude(place.getLongitude())
+                                .categoryName(place.getCategory().getName()).score(place.getScore())
+                                .placeImageDtos(place.getPlaceImages().stream()
+                                                .map(PlaceImageDto::from)
+                                                .collect(Collectors.toList()))
+                                .build();
 
-    }
+        }
+
+        /**
+         * 장소 이미지 업로드
+         * 
+         * @param placeId 장소 ID
+         * @param file 업로드할 이미지 파일
+         * @return 업로드된 이미지 정보
+         */
+        @Transactional
+        public PlaceImageDto uploadPlaceImage(Long placeId, MultipartFile file) {
+                Place place = placeRepository.findById(placeId)
+                                .orElseThrow(() -> new BusinessException(PlaceErrorCode.NOT_FOUND));
+
+                // 공통 이미지 서비스를 사용하여 이미지 업로드
+                ImageResponseDto imageResponseDto =
+                                imageService.uploadImage(file, "place", placeId);
+
+                // 장소 이미지 엔티티 생성 및 저장
+                PlaceImage placeImage = new PlaceImage();
+                placeImage.setImageUrl(imageResponseDto.getImageUrl());
+                placeImage.setPlace(place);
+
+                place.getPlaceImages().add(placeImage);
+                placeRepository.save(place);
+
+                log.info("Place image uploaded for place ID {}: {}", placeId,
+                                imageResponseDto.getImageUrl());
+
+                return PlaceImageDto.from(placeImage);
+        }
+
+        /**
+         * 장소 대표 이미지(썸네일) 업데이트
+         * 
+         * @param placeId 장소 ID
+         * @param file 업로드할 이미지 파일
+         * @return 업데이트된 장소 정보
+         */
+        @Transactional
+        public PlaceDetailDto updatePlaceThumbnail(Long placeId, MultipartFile file) {
+                Place place = placeRepository.findById(placeId)
+                                .orElseThrow(() -> new BusinessException(PlaceErrorCode.NOT_FOUND));
+
+                // 기존 썸네일 이미지가 있으면 삭제
+                String oldThumbnail = place.getThumbnail();
+                if (oldThumbnail != null && !oldThumbnail.isEmpty()) {
+                        imageService.deleteImage(oldThumbnail);
+                }
+
+                // 새 이미지 업로드
+                ImageResponseDto imageResponseDto =
+                                imageService.uploadImage(file, "place", placeId);
+
+                // 장소 썸네일 업데이트
+                place.setThumbnail(imageResponseDto.getImageUrl());
+                placeRepository.save(place);
+
+                log.info("Place thumbnail updated for place ID {}: {}", placeId,
+                                imageResponseDto.getImageUrl());
+
+                return getPlaceDetail(placeId);
+        }
 }

--- a/src/main/java/com/server/global/controller/ImageController.java
+++ b/src/main/java/com/server/global/controller/ImageController.java
@@ -1,0 +1,88 @@
+package com.server.global.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.server.domain.user.entity.User;
+import com.server.global.dto.ApiResponseDto;
+import com.server.global.dto.ImageResponseDto;
+import com.server.global.service.ImageService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 공통 이미지 업로드 API 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+@Slf4j
+public class ImageController {
+
+    private final ImageService imageService;
+
+    /**
+     * 이미지 업로드 API
+     * 
+     * @param user 인증된 사용자
+     * @param file 업로드할 이미지 파일
+     * @param entityType 이미지를 사용할 엔티티 타입 (예: "user", "place", "course")
+     * @param entityId 엔티티의 ID (선택 사항, null 가능)
+     * @return 업로드된 이미지 정보
+     */
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponseDto<ImageResponseDto> uploadImage(@AuthenticationPrincipal User user,
+            @RequestPart("file") MultipartFile file, @RequestParam("entityType") String entityType,
+            @RequestParam(value = "entityId", required = false) Long entityId) {
+
+        log.info("Image upload requested for entity type: {}, entity ID: {}, by user: {}",
+                entityType, entityId, user.getNickname());
+
+        if (!imageService.validateImage(file)) {
+            String errorMessage = imageService.getValidationErrorMessage(file);
+            log.warn("Image validation failed: {}", errorMessage);
+            return ApiResponseDto.error(HttpStatus.BAD_REQUEST.value(), errorMessage);
+        }
+
+        try {
+            ImageResponseDto responseDto = imageService.uploadImage(file, entityType, entityId);
+            return ApiResponseDto.success(HttpStatus.OK.value(), responseDto);
+        } catch (Exception e) {
+            log.error("Failed to upload image", e);
+            return ApiResponseDto.error(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                    "Failed to upload image: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 이미지 삭제 API
+     * 
+     * @param imageUrl 삭제할 이미지의 URL (인코딩된 URL)
+     * @return 삭제 결과
+     */
+    @DeleteMapping("/{imageUrl}")
+    public ApiResponseDto<Void> deleteImage(@AuthenticationPrincipal User user,
+            @PathVariable String imageUrl) {
+
+        log.info("Image deletion requested for URL: {}, by user: {}", imageUrl, user.getNickname());
+
+        try {
+            imageService.deleteImage(imageUrl);
+            return ApiResponseDto.success(HttpStatus.OK.value(), null);
+        } catch (Exception e) {
+            log.error("Failed to delete image", e);
+            return ApiResponseDto.error(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                    "Failed to delete image: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/server/global/dto/ImageResponseDto.java
+++ b/src/main/java/com/server/global/dto/ImageResponseDto.java
@@ -1,0 +1,33 @@
+package com.server.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 이미지 업로드에 대한 응답 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ImageResponseDto {
+
+    /**
+     * 이미지 URL (CDN URL)
+     */
+    private String imageUrl;
+
+    /**
+     * 이미지를 사용하는 엔티티 타입
+     */
+    private String entityType;
+
+    /**
+     * 이미지와 관련된 엔티티 ID (없는 경우 null)
+     */
+    private Long entityId;
+}

--- a/src/main/java/com/server/global/service/ImageService.java
+++ b/src/main/java/com/server/global/service/ImageService.java
@@ -1,0 +1,44 @@
+package com.server.global.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.server.global.dto.ImageResponseDto;
+
+/**
+ * 이미지 업로드 및 관리를 위한 서비스 인터페이스
+ */
+public interface ImageService {
+
+    /**
+     * 이미지 파일을 업로드하고 URL을 반환
+     * 
+     * @param file 업로드할 이미지 파일
+     * @param entityType 이미지를 사용하는 엔티티 타입 (예: "user", "place", "course")
+     * @param entityId 엔티티의 ID (null 가능, 새로운 엔티티의 경우)
+     * @return 업로드된 이미지 정보를 담은 DTO
+     */
+    ImageResponseDto uploadImage(MultipartFile file, String entityType, Long entityId);
+
+    /**
+     * URL로부터 이미지 삭제
+     * 
+     * @param imageUrl 삭제할 이미지의 URL
+     */
+    void deleteImage(String imageUrl);
+
+    /**
+     * 이미지 파일 유효성 검증 (확장자, 크기 등)
+     * 
+     * @param file 검증할 이미지 파일
+     * @return 유효성 검증 결과 (true: 유효, false: 유효하지 않음)
+     */
+    boolean validateImage(MultipartFile file);
+
+    /**
+     * 이미지 파일이 유효하지 않은 이유 반환
+     * 
+     * @param file 검증할 이미지 파일
+     * @return 유효성 검증 실패 이유 (유효한 경우 null)
+     */
+    String getValidationErrorMessage(MultipartFile file);
+}

--- a/src/main/java/com/server/global/service/ImageServiceImpl.java
+++ b/src/main/java/com/server/global/service/ImageServiceImpl.java
@@ -1,0 +1,115 @@
+package com.server.global.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.server.global.dto.ImageResponseDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 이미지 업로드 및 관리를 위한 서비스 구현체
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ImageServiceImpl implements ImageService {
+
+    private final S3Service s3Service;
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+    /**
+     * 이미지 파일을 업로드하고 URL을 반환
+     * 
+     * @param file 업로드할 이미지 파일
+     * @param entityType 이미지를 사용하는 엔티티 타입 (예: "user", "place", "course")
+     * @param entityId 엔티티의 ID (null 가능, 새로운 엔티티의 경우)
+     * @return 업로드된 이미지 정보를 담은 DTO
+     */
+    @Override
+    public ImageResponseDto uploadImage(MultipartFile file, String entityType, Long entityId) {
+        if (!validateImage(file)) {
+            throw new IllegalArgumentException(getValidationErrorMessage(file));
+        }
+
+        // 표준화된 디렉토리 경로 생성 (entityType/entityId 또는 entityType/temp)
+        String directory = entityType;
+        if (entityId != null) {
+            directory += "/" + entityId;
+        } else {
+            directory += "/temp";
+        }
+
+        // S3에 이미지 업로드
+        String imageUrl = s3Service.uploadImage(file, directory);
+
+        // 응답 DTO 생성
+        return ImageResponseDto.builder().imageUrl(imageUrl).entityType(entityType)
+                .entityId(entityId).build();
+    }
+
+    /**
+     * URL로부터 이미지 삭제
+     * 
+     * @param imageUrl 삭제할 이미지의 URL
+     */
+    @Override
+    public void deleteImage(String imageUrl) {
+        s3Service.deleteImage(imageUrl);
+    }
+
+    /**
+     * 이미지 파일 유효성 검증 (확장자, 크기 등)
+     * 
+     * @param file 검증할 이미지 파일
+     * @return 유효성 검증 결과 (true: 유효, false: 유효하지 않음)
+     */
+    @Override
+    public boolean validateImage(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            return false;
+        }
+
+        // 파일 크기 검증
+        if (file.getSize() > MAX_FILE_SIZE) {
+            return false;
+        }
+
+        // 파일 형식 검증
+        String contentType = file.getContentType();
+        if (contentType == null
+                || !(contentType.equals("image/jpeg") || contentType.equals("image/png")
+                        || contentType.equals("image/jpg") || contentType.equals("image/gif"))) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * 이미지 파일이 유효하지 않은 이유 반환
+     * 
+     * @param file 검증할 이미지 파일
+     * @return 유효성 검증 실패 이유 (유효한 경우 null)
+     */
+    @Override
+    public String getValidationErrorMessage(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            return "Empty file provided";
+        }
+
+        if (file.getSize() > MAX_FILE_SIZE) {
+            return "File size exceeds 5MB limit";
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null
+                || !(contentType.equals("image/jpeg") || contentType.equals("image/png")
+                        || contentType.equals("image/jpg") || contentType.equals("image/gif"))) {
+            return "Only JPEG, PNG, JPG and GIF images are allowed";
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## 변경 사항 요약
이번 PR은 이미지 업로드 기능을 사용자 프로필에서 다른 엔티티(Place, Course 등)로 확장하고, 일관된 CDN URI 저장 체계를 구축하는 내용을 포함하고 있습니다.

### 주요 변경 사항:

1. **공통 이미지 업로드 API**
   - `ImageService` 인터페이스와 `ImageServiceImpl` 구현체 생성
   - 모든 엔티티에서 공통으로 사용할 수 있는 이미지 관련 기능 구현
   - 이미지 업로드, 삭제, 유효성 검증 등의 공통 메소드 제공

2. **CDN URI 표준화**
   - S3 URI를 일관된 CDN URI로 자동 변환하는 메커니즘
   - 엔티티 타입별 디렉토리 구조 표준화 (예: `user/1`, `place/2`, `course/3`)

3. **통합된 이미지 응답 DTO**
   - `ImageResponseDto` 클래스 생성으로 이미지 응답 구조 표준화
   - 이미지 URL, 엔티티 타입, 엔티티 ID 정보 포함

4. **플레이스 및 코스 이미지 업로드 API**
   - `PlaceService` 및 `CourseService`에 이미지 업로드 기능 구현
   - 각 서비스에 대한 이미지 업로드 및 썸네일 업데이트 엔드포인트 추가

5. **기존 사용자 서비스 마이그레이션**
   - 기존 `UserService`의 이미지 업로드 로직을 공통 서비스 사용으로 변경

## 관련 이슈
- Resolves #92