### PR TITLE
refactor: 커플 연결 시, 처음 만난 날 옵션 설정 가능하도록 수정

### DIFF
--- a/src/main/java/com/server/domain/user/controller/CoupleController.java
+++ b/src/main/java/com/server/domain/user/controller/CoupleController.java
@@ -41,7 +41,8 @@ public class CoupleController {
     public ApiResponseDto<CoupleDto> connectCouple(@AuthenticationPrincipal User user,
             @RequestBody CoupleConnectionRequestDto requestDto) {
 
-        CoupleDto coupleDto = coupleService.connectCouple(user, requestDto.getPartnerCode());
+        CoupleDto coupleDto = coupleService.connectCouple(user, requestDto.getPartnerCode(),
+            requestDto.getFirstMetDate());
 
         return ApiResponseDto.success(HttpStatus.CREATED.value(), coupleDto);
     }

--- a/src/main/java/com/server/domain/user/dto/CoupleConnectionRequestDto.java
+++ b/src/main/java/com/server/domain/user/dto/CoupleConnectionRequestDto.java
@@ -20,4 +20,8 @@ public class CoupleConnectionRequestDto {
 
     @Schema(description = "상대방 유저 고유 코드", example = "ABC123")
     private String partnerCode;
+
+    @Schema(description = "설정할 처음 만난 날짜", example = "2025-01-01")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate firstMetDate;
 }

--- a/src/main/java/com/server/domain/user/service/CoupleService.java
+++ b/src/main/java/com/server/domain/user/service/CoupleService.java
@@ -35,7 +35,7 @@ public class CoupleService {
      * @return 생성된 커플 정보를 담은 DTO
      */
     @Transactional
-    public CoupleDto connectCouple(User user, String partnerCode) {
+    public CoupleDto connectCouple(User user, String partnerCode, LocalDate firstMetDate) {
         // 1. 현재 유저가 이미 커플인지 확인
         if (user.isConnectedCouple()) {
             throw new BusinessException(CoupleErrorCode.ALREADY_CONNECTED);
@@ -56,7 +56,7 @@ public class CoupleService {
         }
 
         // 5. 커플 생성 및 저장
-        Couple couple = new Couple(user, partner, null);
+        Couple couple = new Couple(user, partner, firstMetDate);
         coupleRepository.save(couple);
         log.info("새로운 커플이 연결되었습니다. 유저1: {}, 유저2: {}", user.getNickname(), partner.getNickname());
 

--- a/src/test/java/com/server/domain/user/controller/CoupleControllerTest.java
+++ b/src/test/java/com/server/domain/user/controller/CoupleControllerTest.java
@@ -95,9 +95,10 @@ public class CoupleControllerTest {
         // Setup mock data
         CoupleConnectionRequestDto requestDto = new CoupleConnectionRequestDto();
         requestDto.setPartnerCode("PARTNER_CODE");
+        requestDto.setFirstMetDate(LocalDate.of(2025, 1, 1));
 
         // Setup mock coupleService behavior
-        when(coupleService.connectCouple(any(User.class), any(String.class)))
+        when(coupleService.connectCouple(any(User.class), any(String.class), any(LocalDate.class)))
                 .thenReturn(mockCoupleDto);
 
         // Execute request with JWT authentication and verify response

--- a/src/test/java/com/server/domain/user/service/CoupleServiceTest.java
+++ b/src/test/java/com/server/domain/user/service/CoupleServiceTest.java
@@ -88,7 +88,7 @@ public class CoupleServiceTest {
         });
 
         // Call the method
-        CoupleDto result = coupleService.connectCouple(user1, "USER2_CODE");
+        CoupleDto result = coupleService.connectCouple(user1, "USER2_CODE", firstMetDate);
 
         // Verify
         assertNotNull(result);
@@ -106,7 +106,7 @@ public class CoupleServiceTest {
 
         // Call and verify
         BusinessException exception = assertThrows(BusinessException.class, () -> {
-            coupleService.connectCouple(user1, "USER2_CODE");
+            coupleService.connectCouple(user1, "USER2_CODE", firstMetDate);
         });
 
         assertEquals(CoupleErrorCode.ALREADY_CONNECTED, exception.getErrorCode());
@@ -120,7 +120,7 @@ public class CoupleServiceTest {
 
         // Call and verify
         BusinessException exception = assertThrows(BusinessException.class, () -> {
-            coupleService.connectCouple(user1, "NONEXISTENT_CODE");
+            coupleService.connectCouple(user1, "NONEXISTENT_CODE", firstMetDate);
         });
 
         assertEquals(CoupleErrorCode.PARTNER_NOT_FOUND, exception.getErrorCode());
@@ -134,7 +134,7 @@ public class CoupleServiceTest {
 
         // Call and verify
         BusinessException exception = assertThrows(BusinessException.class, () -> {
-            coupleService.connectCouple(user1, "USER1_CODE");
+            coupleService.connectCouple(user1, "USER1_CODE", firstMetDate);
         });
 
         assertEquals(CoupleErrorCode.SELF_CONNECTION_NOT_ALLOWED, exception.getErrorCode());
@@ -149,7 +149,7 @@ public class CoupleServiceTest {
 
         // Call and verify
         BusinessException exception = assertThrows(BusinessException.class, () -> {
-            coupleService.connectCouple(user1, "USER2_CODE");
+            coupleService.connectCouple(user1, "USER2_CODE", firstMetDate);
         });
 
         assertEquals(CoupleErrorCode.PARTNER_ALREADY_CONNECTED, exception.getErrorCode());


### PR DESCRIPTION
## 📋 Summary
커플 연결 시, '처음 만날 날' 옵션 설정 가능하도록 수정하였습니다.

---

## 🔗 Related Issue

<!-- 이 PR이 해결하는 이슈 번호를 명시하세요. 예: Resolves #104 -->
Resolves #12

---

## 🚀 Changes Made

### 1. CoupleConnectionRequestDto
- firstMetDate 필드 추가
```java
@Getter
@Setter
@NoArgsConstructor
@AllArgsConstructor
@Builder
public class CoupleConnectionRequestDto {

    @Schema(description = "상대방 유저 고유 코드", example = "ABC123")
    private String partnerCode;

    @Schema(description = "설정할 처음 만난 날짜", example = "2025-01-01")
    @JsonFormat(pattern = "yyyy-MM-dd")
    private LocalDate firstMetDate;
}
```