### PR TITLE
Issue#125/feat/user logout

### DIFF
--- a/src/main/java/com/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/domain/user/controller/UserController.java
@@ -98,4 +98,16 @@ public class UserController {
 
         return ApiResponseDto.success(HttpStatus.OK.value(), message);
     }
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "로그인한 유저 로그아웃")
+    public ApiResponseDto<String> logout(@AuthenticationPrincipal User user) {
+
+        // TODO: Redis에서 refresh token 관리
+        userService.clearRefreshToken(user.getId());
+        return ApiResponseDto.success(HttpStatus.OK.value(), "Logout successful");
+    }
+
 }

--- a/src/main/java/com/server/domain/user/service/UserService.java
+++ b/src/main/java/com/server/domain/user/service/UserService.java
@@ -303,4 +303,13 @@ public class UserService {
 
         return UserProfileResponseDto.from(user);
     }
+
+    @Transactional
+    public void clearRefreshToken(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.NOT_FOUND));
+        user.updateRefreshToken(null);
+        userRepository.save(user);
+        log.info("Cleared refresh token for user ID: {}", userId);
+    }
 }

--- a/src/main/java/com/server/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/server/global/error/handler/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.server.global.error.handler;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -38,6 +39,13 @@ public class GlobalExceptionHandler {
         String errorMessage = e.getBindingResult().getFieldErrors().stream()
             .map(DefaultMessageSourceResolvable::getDefaultMessage)
             .collect(Collectors.joining(", "));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponseDto.error(HttpStatus.BAD_REQUEST.value(), errorMessage));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponseDto<Object>> handleJsonParseException(HttpMessageNotReadableException e) {
+        String errorMessage = "요청 본문의 JSON 형식이 올바르지 않습니다.";
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(ApiResponseDto.error(HttpStatus.BAD_REQUEST.value(), errorMessage));
     }

--- a/src/test/java/com/server/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/server/domain/user/service/UserServiceTest.java
@@ -324,4 +324,19 @@ public class UserServiceTest {
         assertEquals(originalNickname, user.getNickname());
         verify(userRepository).save(user);
     }
+
+    @Test
+    @DisplayName("Set refresh token null test - logout user")
+    void logoutUserTest() {
+        // given
+        user.setRefreshToken("dummy-refresh-token");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        // when
+        userService.clearRefreshToken(1L);
+
+        // then
+        assertNull(user.getRefreshToken());
+        verify(userRepository).save(user);
+    }
 }


### PR DESCRIPTION
## 📋 Summary
- 로그아웃 구현
- 요청 정보 json 파싱 예외 핸들링해서 ErrorDTO 형식으로 나오게 수정
---

## 🔗 Related Issue

<!-- 이 PR이 해결하는 이슈 번호를 명시하세요. 예: Resolves #104 -->
Resolves #125

---

## 🚀 Changes Made

### 1. 로그아웃 시 Refresh 토큰 만료
UserService
```java
@Transactional
    public void clearRefreshToken(Long userId) {
        User user = userRepository.findById(userId)
                .orElseThrow(() -> new BusinessException(UserErrorCode.NOT_FOUND));
        user.updateRefreshToken(null);
        userRepository.save(user);
        log.info("Cleared refresh token for user ID: {}", userId);
    }
```
### 2. 요청 정보 json 파싱 예외 핸들링
GlobalExceptionHandler
```java
@ExceptionHandler(HttpMessageNotReadableException.class)
    public ResponseEntity<ApiResponseDto<Object>> handleJsonParseException(HttpMessageNotReadableException e) {
        String errorMessage = "요청 본문의 JSON 형식이 올바르지 않습니다.";
        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
            .body(ApiResponseDto.error(HttpStatus.BAD_REQUEST.value(), errorMessage));
    }
```
