### PR TITLE
fix: 커플 연결 해제 후 내 정보 조회 시 예외 발생

### DIFF
--- a/src/main/java/com/server/domain/user/service/CoupleService.java
+++ b/src/main/java/com/server/domain/user/service/CoupleService.java
@@ -77,7 +77,7 @@ public class CoupleService {
                 .orElseThrow(() -> new BusinessException(CoupleErrorCode.COUPLE_NOT_FOUND));
 
         if( couple.getDeletedAt() != null) {
-            throw new BusinessException(CoupleErrorCode.COUPLE_ALREADY_DISCONNECTED);
+            throw new BusinessException(CoupleErrorCode.COUPLE_NOT_FOUND);
         }
 
         return CoupleDto.from(couple, user, s3UrlConfig);

--- a/src/test/java/com/server/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/server/domain/user/service/UserServiceTest.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 
 import com.server.domain.user.dto.CoupleDto;
 import com.server.domain.user.dto.NotificationSettingsDto;
+import com.server.global.error.code.CoupleErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -95,6 +96,31 @@ public class UserServiceTest {
         assertEquals("USER123", userDto.getCode());
         assertFalse(userDto.getRestoreEnabled());
         assertTrue(userDto.getIsRegistered());
+    }
+
+    @Test
+    @DisplayName("Get user with disconnected couple test")
+    void getUserWithDisconnectedCoupleTest() {
+        // Setup all required terms as agreed
+        for (TermAgreement agreement : user.getTermAgreements()) {
+            agreement.setAgreed(true);
+        }
+
+        // Simulate couple being disconnected
+        when(coupleService.getCouple(any())).thenThrow(new BusinessException(CoupleErrorCode.COUPLE_NOT_FOUND));
+
+        // Call the method
+        UserDto userDto = userService.getUser(user);
+
+        // Verify the results
+        assertNotNull(userDto);
+        assertEquals("testUser", userDto.getNickname());
+        assertEquals("thumbnail.jpg", userDto.getThumbnail());
+        assertEquals("USER123", userDto.getCode());
+        assertFalse(userDto.getRestoreEnabled());
+        assertTrue(userDto.getIsRegistered());
+        assertFalse(userDto.getHasCouple());
+        assertNull(userDto.getCouple());
     }
 
     @Test


### PR DESCRIPTION
## 📋 Summary
커플 연결 해제 후 내 정보 조회 시 커플 관련 예외가 발생하던 문제를 수정하였습니다. 커플 연결이 해제된 경우에는 커플 정보를 null로 반환하도록 변경하였습니다.

---

## 🔗 Related Issue

<!-- 이 PR이 해결하는 이슈 번호를 명시하세요. 예: Resolves #104 -->
Resolves #136

---

## 🚀 Changes Made

### 1. `CoupleService` 변경
```java 
@Transactional(readOnly = true)
    public CoupleDto getCouple(User user) {
        Couple couple = coupleRepository.findByUser1OrUser2(user, user)
                .orElseThrow(() -> new BusinessException(CoupleErrorCode.COUPLE_NOT_FOUND));

        if( couple.getDeletedAt() != null) {
            throw new BusinessException(CoupleErrorCode.COUPLE_NOT_FOUND);
        }

        return CoupleDto.from(couple, user, s3UrlConfig);
    }
```
커플 연결이 해제된 경우도 `BusinessException(CoupleErrorCode.COUPLE_NOT_FOUND)` 예외가 발생하도록 수정하였습니다.
