### PR TITLE
fix: 계정 초기화 시 deletedAt을 제거하여 새로 시작 가능한 상태로 변경

### DIFF
--- a/src/main/java/com/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/domain/user/controller/UserController.java
@@ -82,7 +82,7 @@ public class UserController {
             nickname = userService.restoreAccount(user.getId());
             message = String.format("User account %s restored successfully", nickname);
         } else {
-            // 계정 삭제
+            // 계정 초기화
             nickname = userService.deleteUser(user, false);
             message = String.format("User account %s deleted successfully", nickname);
         }

--- a/src/main/java/com/server/domain/user/service/UserService.java
+++ b/src/main/java/com/server/domain/user/service/UserService.java
@@ -78,9 +78,9 @@ public class UserService {
             log.info("User account '{}' marked for deletion (soft delete).", originalNickname);
         } else { // False: User wants to "Start Anew" (e.g., POST /api/users/restore with restore:
                  // false)
-            // Reset the account for re-registration, do not hard delete.
-            // 1. Set deletedAt to signify the account is in a reset/inactive state.
-            user.setDeletedAt(LocalDateTime.now());
+
+            // 1. Clear soft delete timestamp
+            user.setDeletedAt(null);
 
             // 2. Reset all term agreements to false
             if (user.getTermAgreements() != null) {
@@ -94,7 +94,7 @@ public class UserService {
             // 3. Reset user-specific profile data
             user.setThumbnail(null); // Clear profile picture
             user.updateRefreshToken(null); // Clear refresh token
-
+            user.setNickname(null); // Clear nickname to allow re-registration
             userRepository.save(user); // Save the updated user entity
             log.info("User account '{}' has been reset for re-registration.", originalNickname);
         }

--- a/src/test/java/com/server/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/server/domain/user/service/UserServiceTest.java
@@ -172,9 +172,10 @@ public class UserServiceTest {
 
         // Verify the results
         assertEquals("testUser", result); // Should return original nickname
-        assertNotNull(user.getDeletedAt()); // deletedAt should be set
+        assertNull(user.getDeletedAt()); // deletedAt should be set
         assertNull(user.getThumbnail()); // Thumbnail should be cleared
         assertNull(user.getRefreshToken()); // Refresh token should be cleared
+        assertNull(user.getNickname());
 
         // Verify term agreements are reset
         for (TermAgreement agreement : user.getTermAgreements()) {


### PR DESCRIPTION
### Features

+ USER
  + FIX: 계정 초기화 시 deletedAt을 제거하여 새로 시작 가능한 상태로 변경 (resolves: #141)