### PR TITLE
feat: 유저 알림 설정 조회 기능 추가 및 유저 알림 설정 변경 API 로직 수정

### DIFF
--- a/src/main/java/com/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/domain/user/controller/UserController.java
@@ -118,13 +118,27 @@ public class UserController {
 
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @ResponseStatus(HttpStatus.OK)
-    @PutMapping(value = "/notifications/settings")
+    @PatchMapping(value = "/notifications/settings")
+    @Operation(summary = "알림 설정 업데이트",
+        description = "사용자의 알림 설정을 업데이트합니다. 데이트 알림 설정이 필수입니다.")
     public ApiResponseDto<String> updateNotificationSettings(
-        @AuthenticationPrincipal User user, @Valid @RequestBody NotificationSettingsDto requestDto) {
+        @AuthenticationPrincipal User user, @Valid @RequestBody NotificationSettingRequestDto requestDto) {
 
         log.info("Notification settings update requested for user: {}", user.getNickname());
 
         userService.updateNotificationSettings(user, requestDto);
         return ApiResponseDto.success(HttpStatus.OK.value(), "Notification settings updated successfully");
+    }
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping(value = "/notifications/settings")
+    @Operation(summary = "알림 설정 조회",
+        description = "사용자의 알림 설정을 조회합니다. 데이트 알림 설정이 포함됩니다.")
+    public ApiResponseDto<UserNotificationSettingResponseDto> getNotificationSettings(@AuthenticationPrincipal User user) {
+        log.info("Notification settings retrieval requested for user: {}", user.getNickname());
+
+        UserNotificationSettingResponseDto responseDto = userService.getNotificationSettings(user);
+        return ApiResponseDto.success(HttpStatus.OK.value(), responseDto);
     }
 }

--- a/src/main/java/com/server/domain/user/dto/NotificationSettingRequestDto.java
+++ b/src/main/java/com/server/domain/user/dto/NotificationSettingRequestDto.java
@@ -11,11 +11,9 @@ import lombok.Setter;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class NotificationSettingsDto {
+public class NotificationSettingRequestDto {
     @Schema(description = "데이트 알림 설정", example = "true")
-    @NotNull(message = "데이트 알림 설정은 필수 항목입니다.")
     private Boolean dateNotificationEnabled;
     @Schema(description = "이벤트 알림 설정", example = "true")
-    @NotNull(message = "이벤트 알림 설정은 필수 항목입니다.")
     private Boolean eventNotificationEnabled;
 }

--- a/src/main/java/com/server/domain/user/dto/UserDto.java
+++ b/src/main/java/com/server/domain/user/dto/UserDto.java
@@ -5,25 +5,32 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.server.domain.user.entity.User;
 import com.server.global.config.S3UrlConfig;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 public class UserDto {
+    @Schema(description = "사용자 닉네임", example = "위디1호")
     private String nickname;
+    @Schema(description = "프로필 이미지 URL", example = "https://cdn.example.com/user/6/uuid.jpg")
     private String thumbnail;
+    @Schema(description = "복구 가능 여부", example = "true")
     private Boolean restoreEnabled;
+    @Schema(description = "약관 동의 여부", example = "true")
     private Boolean isRegistered;
+    @Schema(description = "사용자 고유 코드", example = "aB3jK2M8p9cR1Vw_K0Nxug")
     private String code;
+    @Schema(description = "커플 여부", example = "true")
     private Boolean hasCouple;
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "커플 정보", nullable = true)
     private CoupleDto couple;
-
     public UserDto() {
         // Default constructor
     }

--- a/src/main/java/com/server/domain/user/dto/UserNotificationSettingResponseDto.java
+++ b/src/main/java/com/server/domain/user/dto/UserNotificationSettingResponseDto.java
@@ -1,0 +1,24 @@
+package com.server.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserNotificationSettingResponseDto {
+    private Long userId;
+    private Boolean dateNotificationEnabled;
+    private Boolean eventNotificationEnabled;
+
+    public static UserNotificationSettingResponseDto of(Long userId, Boolean dateNotificationEnabled, Boolean eventNotificationEnabled) {
+        return UserNotificationSettingResponseDto.builder()
+                .dateNotificationEnabled(dateNotificationEnabled)
+                .eventNotificationEnabled(eventNotificationEnabled)
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/main/java/com/server/domain/user/dto/UserProfileResponseDto.java
+++ b/src/main/java/com/server/domain/user/dto/UserProfileResponseDto.java
@@ -24,6 +24,7 @@ public class UserProfileResponseDto {
             example = "https://cdn.withiy.com/users/profile/abc123.jpg")
     private String profileImageUrl;
 
+    @Schema(description = "커플 여부", example = "true")
     private Boolean hasCouple;
 
     public static UserProfileResponseDto from(User user) {

--- a/src/main/java/com/server/domain/user/entity/User.java
+++ b/src/main/java/com/server/domain/user/entity/User.java
@@ -116,10 +116,10 @@ public class User {
     private List<Folder> folders = new ArrayList<>();
 
     // date_notification_enabled
-    @Column(name = "date_notification_enabled")
+    @Column(name = "date_notification_enabled", nullable = false)
     private Boolean dateNotificationEnabled = true;
     // event_notification_enabled
-    @Column(name = "event_notification_enabled")
+    @Column(name = "event_notification_enabled", nullable = false)
     private Boolean eventNotificationEnabled = true;
 
 

--- a/src/test/java/com/server/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/server/domain/user/controller/UserControllerTest.java
@@ -165,19 +165,4 @@ public class UserControllerTest {
                 .content(objectMapper.writeValueAsString(restoreAccountDto))).andDo(print())
                 .andExpect(status().isOk());
     }
-
-    @Test
-    @DisplayName("알림 설정 업데이트 테스트 - 필수값이 null일 때 실패")
-    void updateNotificationSettings_withNullValue_shouldFail() throws Exception {
-        // Setup mock data
-        NotificationSettingsDto notificationSettingsDto = new NotificationSettingsDto(null, false);
-
-        // Execute request with JWT authentication and verify response
-        mockMvc.perform(put("/api/users/notifications/settings").with(JwtTestUtil.withJwt(jwtService, mockUser))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(notificationSettingsDto))).andDo(print())
-            .andExpect(status().isBadRequest()) // 실패 기대
-            .andExpect(jsonPath("$.message").value("데이트 알림 설정은 필수 항목입니다."));
-    }
-
 }

--- a/src/test/java/com/server/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/server/domain/user/service/UserServiceTest.java
@@ -14,7 +14,8 @@ import java.util.Optional;
 import com.server.domain.oauth.entity.OAuth;
 import com.server.domain.oauth.repository.OAuthRepository;
 import com.server.domain.user.dto.CoupleDto;
-import com.server.domain.user.dto.NotificationSettingsDto;
+import com.server.domain.user.dto.NotificationSettingRequestDto;
+import com.server.domain.user.dto.UserNotificationSettingResponseDto;
 import com.server.global.error.code.CoupleErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -435,9 +436,8 @@ public class UserServiceTest {
         // given
         Boolean dateNotificationEnabled = true;
         Boolean eventNotificationEnabled = false;
-        NotificationSettingsDto notificationSettingsDto = new NotificationSettingsDto(dateNotificationEnabled, eventNotificationEnabled);
+        NotificationSettingRequestDto notificationSettingsDto = new NotificationSettingRequestDto(dateNotificationEnabled, eventNotificationEnabled);
 
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         // when
         userService.updateNotificationSettings(user, notificationSettingsDto);
 
@@ -447,5 +447,41 @@ public class UserServiceTest {
             () -> assertEquals(eventNotificationEnabled, user.getEventNotificationEnabled())
         );
         verify(userRepository).save(user);
+    }
+
+    @Test
+    @DisplayName("알림 설정 변경 - 데이트 알림 ON, 이벤트 알림 NULL")
+    void updateNotificationSettingsNullTest() {
+        // given
+        Boolean dateNotificationEnabled = true;
+        NotificationSettingRequestDto notificationSettingsDto = new NotificationSettingRequestDto(dateNotificationEnabled, null);
+
+        // when
+        userService.updateNotificationSettings(user, notificationSettingsDto);
+
+        // then
+        assertAll(
+            () -> assertEquals(dateNotificationEnabled, user.getDateNotificationEnabled()),
+            () -> assertTrue(user.getEventNotificationEnabled()) // Default value should be true
+        );
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    @DisplayName("알림 설정 조회 - 데이트 알림 ON, 이벤트 알림 OFF")
+    void getNotificationSettingsTest() {
+        // given
+        user.setDateNotificationEnabled(true);
+        user.setEventNotificationEnabled(false);
+
+        // when
+        UserNotificationSettingResponseDto responseDto = userService.getNotificationSettings(user);
+
+        // then
+        assertAll(
+            () -> assertEquals(user.getId(), responseDto.getUserId()),
+            () -> assertTrue(responseDto.getDateNotificationEnabled()),
+            () -> assertFalse(responseDto.getEventNotificationEnabled())
+        );
     }
 }


### PR DESCRIPTION
### Features

- USER
  - FEAT: 유저 알림 설정 조회 기능 추가 및 유저 알림 설정 변경 API 로직 수정 (related to #141)
  - FIX: 유저 알림 설정 변경 API 로직 수정 (related to #141)
    - PATCH 메서드를 적용하여, 전달되지 않은 필드는 기존 데이터가 유지되도록 구현하였습니다.
  - REFACTOR: DTO 클래스명을 변경하였습니다(`NotificationSettingsDto` -> `NotificationSettingRequestDto`).
