### PR TITLE
fix: 커플 연결 복구 시 restore 요청 정보에 따라 기존 정보 복원 또는 만난 날짜 초기화되도록 수정

### DIFF
--- a/src/main/java/com/server/domain/badge/service/BadgeService.java
+++ b/src/main/java/com/server/domain/badge/service/BadgeService.java
@@ -38,7 +38,7 @@ public class BadgeService {
 
         // 2. 유저가 이미 배지를 획득했는지 확인합니다.
         boolean alreadyClaimed = userBadgeRepository.existsByUserAndBadge(user, badge);
-        if( alreadyClaimed) {
+        if(alreadyClaimed) {
             throw new BadgeException(BadgeErrorCode.BADGE_ALREADY_EXISTS);
         }
 

--- a/src/main/java/com/server/domain/folder/entity/Folder.java
+++ b/src/main/java/com/server/domain/folder/entity/Folder.java
@@ -40,6 +40,7 @@ public class Folder {
     private User user;
 
     @OneToMany(mappedBy = "folder", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<FolderPlace> folderPlaces = new ArrayList<>();
 
     @Column(name = "created_at", nullable = false)

--- a/src/main/java/com/server/domain/place/entity/Place.java
+++ b/src/main/java/com/server/domain/place/entity/Place.java
@@ -60,21 +60,27 @@ public class Place {
     private Category category;
 
     @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<PlaceBookmark> placeBookmarks = new ArrayList<>();
 
     @OneToMany(mappedBy = "place")
+    @Builder.Default
     private List<Album> albums = new ArrayList<>();
 
     @OneToMany(mappedBy = "place")
+    @Builder.Default
     private List<Photo> photos = new ArrayList<>();
 
     @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<CoursePlace> coursePlaces = new ArrayList<>();
 
     @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<Review> reviews = new ArrayList<>();
 
     @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<FolderPlace> folderPlaces = new ArrayList<>();
 
 

--- a/src/main/java/com/server/domain/user/controller/CoupleController.java
+++ b/src/main/java/com/server/domain/user/controller/CoupleController.java
@@ -1,15 +1,12 @@
 package com.server.domain.user.controller;
 
-import com.server.domain.user.dto.CoupleRestoreStatusDto;
+import com.server.domain.user.dto.*;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import com.server.domain.user.dto.CoupleConnectionRequestDto;
-import com.server.domain.user.dto.CoupleDto;
-import com.server.domain.user.dto.FirstMetDateUpdateDto;
 import com.server.domain.user.entity.User;
 import com.server.domain.user.service.CoupleService;
 import com.server.global.dto.ApiResponseDto;
@@ -63,20 +60,11 @@ public class CoupleController {
 
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @ResponseStatus(HttpStatus.OK)
-    @GetMapping("/restore-status")
-    @Operation(summary = "커플 복구 가능 여부 조회", description = "커플 정보가 복구 가능한지 여부를 반환합니다.")
-    public ApiResponseDto<CoupleRestoreStatusDto> getRestoreStatus(@AuthenticationPrincipal User user) {
-        CoupleRestoreStatusDto statusDto = coupleService.getRestoreStatus(user);
-
-        return ApiResponseDto.success(HttpStatus.OK.value(), statusDto);
-    }
-
-    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
-    @ResponseStatus(HttpStatus.OK)
     @PostMapping("/restore")
     @Operation(summary = "커플 연결 복구", description = "현재 로그인한 사용자의 커플 관계를 복구합니다.")
-    public ApiResponseDto<Long> restoreCouple(@AuthenticationPrincipal User user) {
-        Long coupleId = coupleService.restoreCouple(user);
+    public ApiResponseDto<Long> restoreCouple(@AuthenticationPrincipal User user,
+                                              @RequestBody RestoreCoupleDto requestDto) {
+        Long coupleId = coupleService.restoreCouple(user, requestDto.isRestore());
 
         return ApiResponseDto.success(HttpStatus.OK.value(), coupleId);
     }

--- a/src/main/java/com/server/domain/user/dto/CoupleDto.java
+++ b/src/main/java/com/server/domain/user/dto/CoupleDto.java
@@ -30,6 +30,9 @@ public class CoupleDto {
     @Schema(description = "파트너 프로필 이미지", example = "https://example.com/profile.jpg")
     private String partnerThumbnail;
 
+    @Schema(description = "복구 가능 여부", example = "true")
+    private Boolean restoreEnabled;
+
     @Schema(description = "처음 만난 날짜", example = "2025-01-01")
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate firstMetDate;
@@ -40,6 +43,7 @@ public class CoupleDto {
 
     // 현재 사용자 기준으로 파트너 정보를 반환하는 팩토리 메서드
     public static CoupleDto from(Couple couple, User currentUser, S3UrlConfig s3UrlConfig) {
+
         User partner = couple.getUser1().getId().equals(currentUser.getId()) ? couple.getUser2()
                 : couple.getUser1();
 
@@ -51,8 +55,16 @@ public class CoupleDto {
                     thumbnailUrl.replace(s3UrlConfig.getS3Url(), s3UrlConfig.getCloudfrontUrl());
         }
 
-        return CoupleDto.builder().id(couple.getId()).partnerNickname(partner.getNickname())
-                .partnerThumbnail(thumbnailUrl).firstMetDate(couple.getFirstMetDate())
-                .connectedDate(couple.getCreatedAt().toLocalDate()).build();
+        // 복구 가능 여부
+        boolean restoreEnabled = couple.getDeletedAt() != null;
+
+        return CoupleDto.builder()
+            .id(couple.getId())
+            .partnerNickname(partner.getNickname())
+            .partnerThumbnail(thumbnailUrl)
+            .restoreEnabled(restoreEnabled)
+            .firstMetDate(couple.getFirstMetDate())
+            .connectedDate(couple.getCreatedAt().toLocalDate())
+            .build();
     }
 }

--- a/src/main/java/com/server/domain/user/dto/CoupleRestoreStatusDto.java
+++ b/src/main/java/com/server/domain/user/dto/CoupleRestoreStatusDto.java
@@ -10,11 +10,12 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 @Builder
+@Schema(description = "커플 복구 상태 DTO")
 public class CoupleRestoreStatusDto {
     @Schema(description = "커플 고유 ID", example = "1")
     private Long coupleId;
     @Schema(description = "복구 가능 여부", example = "true")
-    private boolean restorable;
+    private boolean restoreEnabled;
     @Schema(description = "삭제된 날짜", example = "2025-04-29T12:34:56")
     private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/server/domain/user/dto/RestoreCoupleDto.java
+++ b/src/main/java/com/server/domain/user/dto/RestoreCoupleDto.java
@@ -8,9 +8,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Schema(description = "계정 복구/초기화 요청 DTO")
-public class RestoreAccountDto {
-
+@Schema(description = "커플 정보 복구/초기화 요청 DTO")
+public class RestoreCoupleDto {
     @Schema(description = "복구 여부 (true: 복구, false: 초기화)", example = "true")
     private boolean restore;
 }

--- a/src/main/java/com/server/domain/user/entity/Couple.java
+++ b/src/main/java/com/server/domain/user/entity/Couple.java
@@ -54,7 +54,7 @@ public class Couple {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    @Column(name = "deletedAt", nullable = true)
+    @Column(name = "deletedAt")
     private LocalDateTime deletedAt;
 
 


### PR DESCRIPTION
## 📋 Summary

커플 연결 복구 요청에 restore 필드를 추가하여 복구 방식을 선택하도록 수정하였습니다. restore이 true이면 만난 날짜 그대로 복원하고, restore이 false이면 만난 날짜를 초기화합니다.



---

## 🔗 Related Issue

<!-- 이 PR이 해결하는 이슈 번호를 명시하세요. 예: Resolves #104 -->
Resolves # 151

---

## 🚀 Changes Made

### 1. [커플 연결 복구 API]() 요청 DTO에 `restore` 필드를 추가하였습니다.
```json
{
  "restore": true
}
```



---

## 📝 API Changes

#### 1. 커플 연결 복구 가능 여부 API를 제거하고, 복구 가능 여부 정보(`restoreEnabled`)를 [커플 정보 조회]() 시 응답에 포함되도록 수정하였습니다.
```json
{
  "status": 0,
  "message": "string",
  "data": {
    "id": 1,
    "partnerNickname": "파트너닉네임",
    "partnerThumbnail": "https://example.com/profile.jpg",
    "restoreEnabled": true,
    "firstMetDate": "2025-01-01",
    "connectedDate": "2025-04-29"
  },
  "timestamp": "2025-07-12T07:00:24.449Z"
}
```
