### PR TITLE
fix: 커플 복구 초기화 이슈 처리

### DIFF
--- a/src/test/java/com/server/domain/user/service/CoupleServiceTest.java
+++ b/src/test/java/com/server/domain/user/service/CoupleServiceTest.java
@@ -283,7 +283,8 @@ public class CoupleServiceTest {
         // Verify
         assertEquals(1L, result);
         assertNull(couple.getDeletedAt());
-        assertNotNull(couple.getFirstMetDate());
+        assertEquals(couple.getFirstMetDate(), LocalDate.of(2025, 1, 1));
+        verify(coupleRepository, never()).delete(couple);
         verify(coupleRepository).save(couple);
     }
 
@@ -296,13 +297,13 @@ public class CoupleServiceTest {
         couple.setDeletedAt(LocalDateTime.now().minusDays(1));
         when(coupleRepository.findByUser1OrUser2(user1, user1)).thenReturn(Optional.of(couple));
 
-        // Call the method
+        // Verify
+        // When
         Long result = coupleService.restoreCouple(user1, requestDto.isRestore());
 
-        // Verify
-        assertEquals(1L, result);
-        assertNull(couple.getDeletedAt());
-        assertNull(couple.getFirstMetDate());
-        verify(coupleRepository).save(couple);
+        // Then
+        assertEquals(1L, result); // 반환은 여전히 couple ID
+        verify(coupleRepository).delete(couple);
+        verify(coupleRepository, never()).save(any());
     }
 }


### PR DESCRIPTION
## ✅ API
`POST /api/couples/restore`

---

## 🔧 변경 사항
`restore` 플래그에 따라 커플 관계를 다음과 같이 처리하도록 수정하였습니다.

- `restore = true`인 경우: 삭제된 커플 관계를 **복구**
- `restore = false`인 경우: 기존에는 커플을 유지하면서 **'처음 만난 날'만 초기화**했으나,  
  이제는 커플 관계를 **완전히 삭제**하도록 동작을 변경

---

## ⚠️ 변경 전 동작
- `restore = false`일 때 커플 관계는 유지됨
- 단지 `처음 만난 날(firstMetDate)`만 null로 초기화

## ✅ 변경 후 동작
- `restore = false`일 때 커플 관계 자체를 완전히 제거 (DB에서 삭제)

---

## 👀 확인 필요 사항
- `restore = false`로 요청 후 `GET /api/users/me` 등 **내 정보 조회 시 커플 정보가 없는지** 확인 부탁드립니다.
