### PR TITLE
Issue#237/feat/search

### DIFF
--- a/src/main/java/com/server/domain/folder/repository/FolderPlaceRepository.java
+++ b/src/main/java/com/server/domain/folder/repository/FolderPlaceRepository.java
@@ -1,6 +1,7 @@
 package com.server.domain.folder.repository;
 
 import com.server.domain.folder.entity.FolderPlace;
+import com.server.domain.folder.repository.projection.PlaceBookmarkProjection;
 import java.util.List;
 import java.util.Set;
 import org.springframework.data.domain.Pageable;
@@ -95,4 +96,16 @@ public interface FolderPlaceRepository extends JpaRepository<FolderPlace, Long> 
 		"JOIN fp.folder f " +
 		"WHERE f.user.id = :userId AND fp.place.id > :cursor")
 	boolean existsPrevPlaceByUser(Long userId, Long cursor);
+
+	@Query("SELECT p.id AS placeId, " +
+		"CASE WHEN EXISTS (" +
+		"   SELECT 1 FROM FolderPlace fp " +
+		"   WHERE fp.place.id = p.id AND fp.folder.user.id = :userId" +
+		") THEN true ELSE false END AS bookmarked " +
+		"FROM Place p " +
+		"WHERE p.id IN :placeIds")
+	List<PlaceBookmarkProjection> findPlaceBookmarks(
+		@Param("placeIds") List<Long> placeIds,
+		@Param("userId") Long userId
+	);
 }

--- a/src/main/java/com/server/domain/folder/repository/projection/PlaceBookmarkProjection.java
+++ b/src/main/java/com/server/domain/folder/repository/projection/PlaceBookmarkProjection.java
@@ -1,0 +1,8 @@
+package com.server.domain.folder.repository.projection;
+
+public interface PlaceBookmarkProjection {
+
+	Long getPlaceId();
+
+	Boolean getBookmarked();
+}

--- a/src/main/java/com/server/domain/folder/service/FolderFacade.java
+++ b/src/main/java/com/server/domain/folder/service/FolderFacade.java
@@ -1,6 +1,5 @@
 package com.server.domain.folder.service;
 
-import com.server.domain.album.service.AlbumService;
 import com.server.domain.folder.dto.FolderOptionDto;
 import com.server.domain.folder.dto.FolderSummaryDto;
 import com.server.domain.folder.dto.PlaceSummaryDto;
@@ -27,7 +26,6 @@ public class FolderFacade {
 	private static final int DEFAULT_THUMBNAIL_LIMIT = 4;
 	private final FolderService folderService;
 	private final PlaceService placeService;
-	private final AlbumService albumService;
 	private final PhotoService photoService;
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/server/domain/folder/service/FolderService.java
+++ b/src/main/java/com/server/domain/folder/service/FolderService.java
@@ -10,10 +10,12 @@ import com.server.domain.folder.entity.FolderPlace;
 import com.server.domain.folder.entity.FolderType;
 import com.server.domain.folder.repository.FolderPlaceRepository;
 import com.server.domain.folder.repository.FolderRepository;
+import com.server.domain.folder.repository.projection.PlaceBookmarkProjection;
 import com.server.domain.place.entity.Place;
 import com.server.domain.user.entity.User;
 import com.server.global.error.code.FolderErrorCode;
 import com.server.global.error.exception.BusinessException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -161,5 +163,16 @@ public class FolderService {
 
 	public void deletePlaceInFolders(Set<Long> folderIds, Long placeId, Long userId) {
 		folderPlaceRepository.deleteByFolderIdsAndPlaceIdAndOwner(folderIds, placeId, userId);
+	}
+
+	public Map<Long, Boolean> getBookmarkMapForPlaces(List<Long> placeIds, Long userId) {
+		if (placeIds == null || placeIds.isEmpty()) {
+			return Collections.emptyMap();
+		}
+		return folderPlaceRepository.findPlaceBookmarks(placeIds, userId).stream()
+			.collect(Collectors.toMap(
+				PlaceBookmarkProjection::getPlaceId,
+				PlaceBookmarkProjection::getBookmarked
+			));
 	}
 }

--- a/src/main/java/com/server/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/server/domain/photo/repository/PhotoRepository.java
@@ -36,7 +36,7 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
 		"WHERE p.place.id IN :placeIds " +
 		"AND p.type = :type " +
 		"ORDER BY p.createdAt DESC")
-	List<Photo> findAllByPlaceIdsAndType(List<Long> placeIds, PhotoType type);
+	List<Photo> findByPlaceIdInAndType(List<Long> placeIds, PhotoType type);
 
 
 	@Query("SELECT p FROM Photo p " +

--- a/src/main/java/com/server/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/server/domain/place/controller/PlaceController.java
@@ -10,6 +10,8 @@ import com.server.domain.place.dto.PlaceDto;
 import com.server.domain.place.dto.PlaceFocusDto;
 import com.server.domain.place.dto.RegisterPhotoRequest;
 import com.server.domain.place.dto.UpdatePlaceDto;
+import com.server.domain.place.dto.reqeust.NearbyPlaceRequest;
+import com.server.domain.place.dto.response.NearbyPlaceResponse;
 import com.server.domain.place.service.PlaceFacade;
 import com.server.domain.place.service.PlaceService;
 import com.server.domain.review.dto.ReviewDto;
@@ -161,5 +163,11 @@ public class PlaceController {
 		@ModelAttribute ApiCursorPaginationRequest pageRequest) {
 		return ApiCursorPaginationResponse.success(HttpStatus.OK.value(),
 			placeFacade.getPlaceReviews(placeId, pageRequest));
+	}
+
+	public ApiResponseDto<NearbyPlaceResponse> getNearbyPlaces(
+		@RequestBody NearbyPlaceRequest request) {
+		NearbyPlaceResponse response = placeFacade.getNearbyPlaces(request);
+		return ApiResponseDto.success(HttpStatus.OK.value(), response);
 	}
 }

--- a/src/main/java/com/server/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/server/domain/place/controller/PlaceController.java
@@ -159,15 +159,19 @@ public class PlaceController {
 	}
 
 	@GetMapping("/{placeId}/reviews")
+	@ResponseStatus(HttpStatus.OK)
 	public ApiCursorPaginationResponse<ReviewDto, Long> getPlaceReviews(@PathVariable Long placeId,
 		@ModelAttribute ApiCursorPaginationRequest pageRequest) {
 		return ApiCursorPaginationResponse.success(HttpStatus.OK.value(),
 			placeFacade.getPlaceReviews(placeId, pageRequest));
 	}
 
-	public ApiResponseDto<NearbyPlaceResponse> getNearbyPlaces(
+	@GetMapping("/nearby")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(summary = "근처 장소 조회", description = "사용자의 현재 위치를 기반으로 근처 장소를 조회합니다.")
+	public ApiResponseDto<NearbyPlaceResponse> getNearbyPlaces(@AuthenticationPrincipal User user,
 		@RequestBody NearbyPlaceRequest request) {
-		NearbyPlaceResponse response = placeFacade.getNearbyPlaces(request);
+		NearbyPlaceResponse response = placeFacade.getNearbyPlaces(user, request);
 		return ApiResponseDto.success(HttpStatus.OK.value(), response);
 	}
 }

--- a/src/main/java/com/server/domain/place/dto/CreatePlaceDto.java
+++ b/src/main/java/com/server/domain/place/dto/CreatePlaceDto.java
@@ -26,9 +26,9 @@ public class CreatePlaceDto {
 	@Schema(description = "장소 지역 3단계", example = "서울숲동")
 	private String region3depth;
 	@Schema(description = "장소 위도", example = "37.5432")
-	private String latitude;
+	private Double latitude;
 	@Schema(description = "장소 경도", example = "127.0423")
-	private String longitude;
+	private Double longitude;
 	@Schema(description = "장소 카테고리 이름", example = "데이트 코스")
 	private String categoryName;
 	@Schema(description = "장소 이미지 URL 목록", example = "[\"https://example.com/image1.jpg\", \"https://example.com/image2.jpg\"]")

--- a/src/main/java/com/server/domain/place/dto/GetPlaceDetailResponse.java
+++ b/src/main/java/com/server/domain/place/dto/GetPlaceDetailResponse.java
@@ -29,15 +29,13 @@ public class GetPlaceDetailResponse {
 	private List<PhotoDto> photos;
 	@Schema(description = "장소 사진 총 개수", example = "100")
 	private long totalPhotoCount;
-	@Schema(description = "더보기 필요 여부 (total > 30)", example = "true")
-	private boolean hasMorePhotos;
 	@Schema(description = "장소 리뷰 목록")
 	private List<ReviewDto> reviews;
 
 	@Builder
 	public GetPlaceDetailResponse(Long placeId, String placeName, CategoryDto category,
 		String address, LocationDto location, Long score, List<PhotoDto> photos,
-		long totalPhotoCount, boolean hasMorePhotos, List<ReviewDto> reviews) {
+		long totalPhotoCount, List<ReviewDto> reviews) {
 		this.placeId = placeId;
 		this.placeName = placeName;
 		this.category = category;
@@ -46,7 +44,6 @@ public class GetPlaceDetailResponse {
 		this.score = score;
 		this.photos = photos;
 		this.totalPhotoCount = totalPhotoCount;
-		this.hasMorePhotos = hasMorePhotos;
 		this.reviews = reviews;
 	}
 }

--- a/src/main/java/com/server/domain/place/dto/LocationDto.java
+++ b/src/main/java/com/server/domain/place/dto/LocationDto.java
@@ -1,5 +1,6 @@
 package com.server.domain.place.dto;
 
+import com.server.domain.place.entity.Place;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,20 +9,30 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LocationDto {
 
-	private String latitude;
-	private String longitude;
+	private double latitude;
+	private double longitude;
 	private String region1depth;
 	private String region2depth;
 	private String region3depth;
 
 	@Builder
-	public LocationDto(String latitude, String longitude, String region1depth, String region2depth,
+	public LocationDto(double latitude, double longitude, String region1depth, String region2depth,
 		String region3depth) {
 		this.latitude = latitude;
 		this.longitude = longitude;
 		this.region1depth = region1depth;
 		this.region2depth = region2depth;
 		this.region3depth = region3depth;
+	}
+
+	public static LocationDto from(Place place) {
+		return LocationDto.builder()
+			.latitude(place.getLatitude())
+			.longitude(place.getLongitude())
+			.region1depth(place.getRegion1depth())
+			.region2depth(place.getRegion2depth())
+			.region3depth(place.getRegion3depth())
+			.build();
 	}
 
 }

--- a/src/main/java/com/server/domain/place/dto/PlaceDetailDto.java
+++ b/src/main/java/com/server/domain/place/dto/PlaceDetailDto.java
@@ -18,8 +18,8 @@ public class PlaceDetailDto {
 	private Long id;
 	private String name;
 	private String address;
-	private String latitude;
-	private String longitude;
+	private Double latitude;
+	private Double longitude;
 	private String region1depth;
 	private String region2depth;
 	private String region3depth;

--- a/src/main/java/com/server/domain/place/dto/PlaceDto.java
+++ b/src/main/java/com/server/domain/place/dto/PlaceDto.java
@@ -2,6 +2,7 @@ package com.server.domain.place.dto;
 
 import com.server.domain.category.dto.CategoryDto;
 import com.server.domain.place.entity.Place;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,27 +19,19 @@ public class PlaceDto {
 	private Long id;
 	private String name;
 	private String address;
-	private String latitude;
-	private String longitude;
-	private String region1depth;
-	private String region2depth;
-	private String region3depth;
+	private LocationDto location;
 	private CategoryDto category;
-	private Long score;
+	private boolean bookmarked;
+	private double score;
+	private List<String> photoUrls;
 
 	public static PlaceDto from(Place place) {
-
 		return PlaceDto.builder()
 			.id(place.getId())
 			.name(place.getName())
 			.address(place.getAddress())
-			.latitude(place.getLatitude())
-			.longitude(place.getLongitude())
-			.region1depth(place.getRegion1depth())
-			.region2depth(place.getRegion2depth())
-			.region3depth(place.getRegion3depth())
+			.location(LocationDto.from(place))
 			.category(CategoryDto.from(place.getCategory()))
-			.score(place.getScore())
 			.build();
 	}
 }

--- a/src/main/java/com/server/domain/place/dto/PlaceDto.java
+++ b/src/main/java/com/server/domain/place/dto/PlaceDto.java
@@ -2,6 +2,7 @@ package com.server.domain.place.dto;
 
 import com.server.domain.category.dto.CategoryDto;
 import com.server.domain.place.entity.Place;
+import java.util.Collections;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,6 +33,20 @@ public class PlaceDto {
 			.address(place.getAddress())
 			.location(LocationDto.from(place))
 			.category(CategoryDto.from(place.getCategory()))
+			.build();
+	}
+
+	public static PlaceDto from(Place place, boolean bookmarked, Double score,
+		List<String> photoUrls) {
+		return PlaceDto.builder()
+			.id(place.getId())
+			.name(place.getName())
+			.address(place.getAddress())
+			.location(LocationDto.from(place))
+			.category(CategoryDto.from(place.getCategory()))
+			.bookmarked(bookmarked)
+			.score(score != null ? score : 0.0)
+			.photoUrls(photoUrls != null ? photoUrls : Collections.emptyList())
 			.build();
 	}
 }

--- a/src/main/java/com/server/domain/place/dto/PlaceDto.java
+++ b/src/main/java/com/server/domain/place/dto/PlaceDto.java
@@ -22,7 +22,7 @@ public class PlaceDto {
 	private LocationDto location;
 	private CategoryDto category;
 	private boolean bookmarked;
-	private double score;
+	private Double score;
 	private List<String> photoUrls;
 
 	public static PlaceDto from(Place place) {

--- a/src/main/java/com/server/domain/place/dto/UpdatePlaceDto.java
+++ b/src/main/java/com/server/domain/place/dto/UpdatePlaceDto.java
@@ -18,8 +18,8 @@ public class UpdatePlaceDto {
 	private String region1depth;
 	private String region2depth;
 	private String region3depth;
-	private String latitude;
-	private String longitude;
+	private Double latitude;
+	private Double longitude;
 	private Long score;
 	private String category;
 }

--- a/src/main/java/com/server/domain/place/dto/reqeust/NearbyPlaceRequest.java
+++ b/src/main/java/com/server/domain/place/dto/reqeust/NearbyPlaceRequest.java
@@ -1,0 +1,12 @@
+package com.server.domain.place.dto.reqeust;
+
+import lombok.Getter;
+
+@Getter
+public class NearbyPlaceRequest {
+
+	private double latitude;
+	private double longitude;
+	private double radius;
+
+}

--- a/src/main/java/com/server/domain/place/dto/reqeust/NearbyPlaceRequest.java
+++ b/src/main/java/com/server/domain/place/dto/reqeust/NearbyPlaceRequest.java
@@ -1,12 +1,22 @@
 package com.server.domain.place.dto.reqeust;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class NearbyPlaceRequest {
 
+	@Schema(description = "위도", example = "37.5665", required = true)
 	private double latitude;
+	@Schema(description = "경도", example = "126.9780", required = true)
 	private double longitude;
+	@Schema(description = "반경(km)", example = "1000", required = true)
 	private double radius;
 
 }

--- a/src/main/java/com/server/domain/place/dto/response/NearbyPlaceResponse.java
+++ b/src/main/java/com/server/domain/place/dto/response/NearbyPlaceResponse.java
@@ -1,0 +1,18 @@
+package com.server.domain.place.dto.response;
+
+import com.server.domain.place.dto.PlaceDto;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NearbyPlaceResponse {
+
+	List<PlaceDto> places;
+
+}

--- a/src/main/java/com/server/domain/place/entity/Place.java
+++ b/src/main/java/com/server/domain/place/entity/Place.java
@@ -54,10 +54,10 @@ public class Place extends BaseTime {
 	private String address;
 
 	@Column(name = "latitude")
-	private String latitude;
+	private Double latitude;
 
 	@Column(name = "longitude")
-	private String longitude;
+	private Double longitude;
 
 	@Column(name = "score")
 	private Long score;
@@ -80,7 +80,7 @@ public class Place extends BaseTime {
 
 	@Builder
 	public Place(String name, String region1depth, String region2depth, String region3depth,
-		String address, String latitude, String longitude, Long score,
+		String address, Double latitude, Double longitude, Long score,
 		User user, Category category, PlaceStatus status) {
 		this.name = name;
 		this.region1depth = region1depth;

--- a/src/main/java/com/server/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/server/domain/place/repository/PlaceRepository.java
@@ -37,4 +37,27 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 
 	@Query("SELECT p FROM Place p WHERE p.id IN :ids")
 	List<Place> findPlacesByIds(List<Long> ids, Sort sort);
+
+	/**
+	 * Haversine 공식을 이용해 각 장소와 기준 좌표 간 거리를 계산
+	 *
+	 * @param latitude
+	 * @param longitude
+	 * @param radiusKm
+	 * @return
+	 */
+	@Query(value =
+		"SELECT p.*, " +
+			"       (6371 * acos(cos(radians(:lat)) * cos(radians(p.latitude)) " +
+			"       * cos(radians(p.longitude) - radians(:lng)) + sin(radians(:lat)) " +
+			"       * sin(radians(p.latitude)))) AS distance " +
+			"FROM place p " +
+			"HAVING distance < :radius " +
+			"ORDER BY distance ASC",
+		nativeQuery = true)
+	List<Place> findNearbyPlaces(
+		@Param("lat") double latitude,
+		@Param("lng") double longitude,
+		@Param("radius") double radiusKm
+	);
 }

--- a/src/main/java/com/server/domain/place/service/PlaceFacade.java
+++ b/src/main/java/com/server/domain/place/service/PlaceFacade.java
@@ -15,8 +15,11 @@ import com.server.domain.place.dto.CreatePlaceDto;
 import com.server.domain.place.dto.CreatePlaceResponse;
 import com.server.domain.place.dto.GetPlaceDetailResponse;
 import com.server.domain.place.dto.LocationDto;
+import com.server.domain.place.dto.PlaceDto;
 import com.server.domain.place.dto.PlaceStatus;
 import com.server.domain.place.dto.RegisterPhotoRequest;
+import com.server.domain.place.dto.reqeust.NearbyPlaceRequest;
+import com.server.domain.place.dto.response.NearbyPlaceResponse;
 import com.server.domain.place.entity.Place;
 import com.server.domain.review.dto.ReviewDto;
 import com.server.domain.review.entity.Review;
@@ -31,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -202,5 +206,22 @@ public class PlaceFacade {
 				return ReviewDto.of(review, review.getUser(), reviewerImageUrls, place.getName());
 			}
 		);
+	}
+
+
+	public NearbyPlaceResponse getNearbyPlaces(NearbyPlaceRequest request) {
+		List<Place> places = placeService.getNearbyPlaces(
+			request.getLatitude(),
+			request.getLongitude(),
+			request.getRadius() // km 단위
+		);
+
+		List<PlaceDto> placeDtos = places.stream()
+			.map(PlaceDto::from)
+			.collect(Collectors.toList());
+
+		return NearbyPlaceResponse.builder()
+			.places(placeDtos)
+			.build();
 	}
 }

--- a/src/main/java/com/server/domain/place/service/PlaceService.java
+++ b/src/main/java/com/server/domain/place/service/PlaceService.java
@@ -234,4 +234,12 @@ public class PlaceService {
 			Place::getId // 커서 기준 값 추출 방법 전달
 		);
 	}
+
+	public List<Place> getNearbyPlaces(double latitude, double longitude, double radius) {
+		return placeRepository.findNearbyPlaces(
+			latitude,
+			longitude,
+			radius // km 단위
+		);
+	}
 }

--- a/src/main/java/com/server/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/server/domain/review/repository/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.server.domain.review.repository;
 
 import com.server.domain.review.entity.Review;
+import com.server.domain.review.repository.projection.PlaceScoreProjection;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
@@ -54,4 +55,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 	boolean existsPrevReviewByPlaceId(@Param("placeId") Long placeId,
 		@Param("cursorUpdatedAt") LocalDateTime cursorUpdatedAt,
 		@Param("cursorScore") Long cursorScore);
+
+	@Query("SELECT r.place.id AS placeId, AVG(r.score) AS avgScore " +
+		"FROM Review r WHERE r.place.id IN :placeIds GROUP BY r.place.id")
+	List<PlaceScoreProjection> findAvgScoreByPlaceIds(@Param("placeIds") List<Long> placeIds);
 }

--- a/src/main/java/com/server/domain/review/repository/projection/PlaceScoreProjection.java
+++ b/src/main/java/com/server/domain/review/repository/projection/PlaceScoreProjection.java
@@ -1,0 +1,8 @@
+package com.server.domain.review.repository.projection;
+
+public interface PlaceScoreProjection {
+
+	Long getPlaceId();
+
+	Double getAvgScore();
+}


### PR DESCRIPTION
# 이번 변경 사항 요약

## 주변 장소 검색 API
- `/nearby` 엔드포인트 추가
- 현재 위치 기준 반경 내 장소 검색 가능
- Haversine 공식을 활용해 정확한 거리 계산

---

## 위도·경도 타입 변경
- 위도/경도 타입을 **String → Double**로 통일
- 좌표 계산의 정밀성과 일관성 확보

---

## 사진·리뷰 조회 개선
- `PhotoService`, `ReviewService`가 **기본 limit** 내부 관리
- 외부 호출 시 limit 파라미터 불필요 → 호출 단순화

---

## Projection 추가
- `PlaceBookmarkProjection`, `PlaceScoreProjection` 도입
- 북마크 여부와 평균 평점을 **단일 쿼리로 효율적 조회**
- N+1 문제 완화

---

## 의존성 정리
- `FolderFacade`, `PlaceFacade`에서 `AlbumService` 의존성 제거
- 코드 단순화

---

## Issue

related #238

