### PR TITLE
fix: 회원가입 시 DB에 유저 약관동의 데이터 저장하도록 수정

### DIFF
--- a/src/main/java/com/server/domain/oauth/service/OAuthFacade.java
+++ b/src/main/java/com/server/domain/oauth/service/OAuthFacade.java
@@ -3,15 +3,12 @@ package com.server.domain.oauth.service;
 import com.server.domain.oauth.dto.OAuth2UserInfo;
 import com.server.domain.oauth.entity.OAuth;
 import com.server.domain.oauth.repository.OAuthRepository;
-import com.server.domain.term.entity.Term;
-import com.server.domain.term.entity.TermAgreement;
 import com.server.domain.term.service.TermService;
 import com.server.domain.user.entity.User;
 import com.server.domain.user.service.UserService;
 import com.server.global.service.ImageService;
 import java.security.SecureRandom;
 import java.util.Base64;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -63,15 +60,7 @@ public class OAuthFacade {
 		OAuth oAuth = userInfo.toEntity(user);
 
 		// ✅ 4. 회원 약관 동의 기록 생성
-		List<Term> terms = termService.findAllTerms();
-		termService.saveAllTermAgreements(
-			terms.stream()
-				.map(term -> TermAgreement.builder()
-					.user(user)
-					.term(term)
-					.build())
-				.toList()
-		);
+		termService.createInitialTermAgreements(user);
 
 		// ✅ 5. 프로필 이미지가 있는 경우 S3 등 업로드 처리
 		updateProfileImageIfExists(user, oAuth, userInfo.getPicture());

--- a/src/main/java/com/server/domain/oauth/service/OAuthFacade.java
+++ b/src/main/java/com/server/domain/oauth/service/OAuthFacade.java
@@ -3,11 +3,15 @@ package com.server.domain.oauth.service;
 import com.server.domain.oauth.dto.OAuth2UserInfo;
 import com.server.domain.oauth.entity.OAuth;
 import com.server.domain.oauth.repository.OAuthRepository;
+import com.server.domain.term.entity.Term;
+import com.server.domain.term.entity.TermAgreement;
+import com.server.domain.term.service.TermService;
 import com.server.domain.user.entity.User;
 import com.server.domain.user.service.UserService;
 import com.server.global.service.ImageService;
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,6 +26,7 @@ public class OAuthFacade {
 	private final OAuthRepository oAuthRepository;
 	private final UserService userService;
 	private final ImageService imageService;
+	private final TermService termService;
 
 	private static final int CODE_LENGTH = 16;
 	private static final SecureRandom RANDOM = new SecureRandom();
@@ -57,10 +62,21 @@ public class OAuthFacade {
 		// ✅ 2. OAuth 엔티티 생성 (User 연관관계 포함)
 		OAuth oAuth = userInfo.toEntity(user);
 
-		// ✅ 3. 프로필 이미지가 있는 경우 S3 등 업로드 처리
+		// ✅ 4. 회원 약관 동의 기록 생성
+		List<Term> terms = termService.findAllTerms();
+		termService.saveAllTermAgreements(
+			terms.stream()
+				.map(term -> TermAgreement.builder()
+					.user(user)
+					.term(term)
+					.build())
+				.toList()
+		);
+
+		// ✅ 5. 프로필 이미지가 있는 경우 S3 등 업로드 처리
 		updateProfileImageIfExists(user, oAuth, userInfo.getPicture());
 
-		// ✅ 4. OAuth 영속화
+		// ✅ 6. OAuth 영속화
 		return oAuthRepository.save(oAuth);
 	}
 

--- a/src/main/java/com/server/domain/term/service/TermService.java
+++ b/src/main/java/com/server/domain/term/service/TermService.java
@@ -5,6 +5,7 @@ import com.server.domain.term.entity.Term;
 import com.server.domain.term.entity.TermAgreement;
 import com.server.domain.term.repository.TermAgreementRepository;
 import com.server.domain.term.repository.TermRepository;
+import com.server.domain.user.entity.User;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -36,8 +37,15 @@ public class TermService {
 		termAgreementRepository.saveAll(agreements);
 	}
 
-	@Transactional(readOnly = true)
-	public List<Term> findAllTerms() {
-		return termRepository.findAll();
+	@Transactional
+	public void createInitialTermAgreements(User user) {
+		List<Term> terms = termRepository.findAll();
+		List<TermAgreement> agreements = terms.stream()
+			.map(term -> TermAgreement.builder()
+				.user(user)
+				.term(term)
+				.build())
+			.toList();
+		termAgreementRepository.saveAll(agreements);
 	}
 }

--- a/src/main/java/com/server/domain/term/service/TermService.java
+++ b/src/main/java/com/server/domain/term/service/TermService.java
@@ -1,6 +1,7 @@
 package com.server.domain.term.service;
 
 import com.server.domain.term.dto.TermDto;
+import com.server.domain.term.entity.Term;
 import com.server.domain.term.entity.TermAgreement;
 import com.server.domain.term.repository.TermAgreementRepository;
 import com.server.domain.term.repository.TermRepository;
@@ -33,5 +34,10 @@ public class TermService {
 	@Transactional
 	public void saveAllTermAgreements(List<TermAgreement> agreements) {
 		termAgreementRepository.saveAll(agreements);
+	}
+
+	@Transactional(readOnly = true)
+	public List<Term> findAllTerms() {
+		return termRepository.findAll();
 	}
 }

--- a/src/main/java/com/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/domain/user/controller/UserController.java
@@ -79,8 +79,7 @@ public class UserController {
 	public ApiResponseDto<String> registerUser(@AuthenticationPrincipal User user,
 		@RequestBody RegisterUserInDto body) {
 		String nickname = userService.registerUser(user, body.getTermAgreements(),
-			body.getNickname(),
-			body.getThumbnail());
+			body.getNickname(), body.getThumbnail());
 		return ApiResponseDto.success(HttpStatus.OK.value(),
 			String.format("User %s information updated successfully", nickname));
 	}

--- a/src/main/java/com/server/domain/user/service/UserService.java
+++ b/src/main/java/com/server/domain/user/service/UserService.java
@@ -14,6 +14,7 @@ import com.server.domain.user.dto.UserProfileResponseDto;
 import com.server.domain.user.entity.Couple;
 import com.server.domain.user.entity.User;
 import com.server.domain.user.repository.UserRepository;
+import com.server.global.error.code.TermErrorCode;
 import com.server.global.error.code.UserErrorCode;
 import com.server.global.error.exception.BusinessException;
 import java.time.LocalDateTime;
@@ -86,7 +87,7 @@ public class UserService {
 	private boolean hasAgreedToAllRequiredTerms(Long userId, List<TermAgreement> agreements) {
 		if (agreements.isEmpty()) {
 			log.warn("User {} has no term agreements.", userId);
-			return false;
+			throw new BusinessException(TermErrorCode.TERM_AGREEMENT_NOT_FOUND);
 		}
 
 		// 필수 약관 중 하나라도 미동의가 있다면 false
@@ -184,6 +185,7 @@ public class UserService {
 
 		// Update user's term agreements based on client request
 		List<TermAgreement> existingAgreements = termService.getUserTermAgreements(user.getId());
+
 		existingAgreements.forEach(agreement -> {
 			Long termId = agreement.getTerm().getId();
 			if (termAgreements.containsKey(termId)) {

--- a/src/main/java/com/server/global/error/code/TermErrorCode.java
+++ b/src/main/java/com/server/global/error/code/TermErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum TermErrorCode implements ErrorCode {
-	REQUIRED_TERM_NOT_AGREED(HttpStatus.BAD_REQUEST.value(), "Required term not agreed.");
+	REQUIRED_TERM_NOT_AGREED(HttpStatus.BAD_REQUEST.value(), "Required term not agreed."),
+	TERM_AGREEMENT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "Term agreement not found.");
 
 	private final int status;
 	private final String message;


### PR DESCRIPTION
## 개요
- `Term`, `TermAgreement` 엔티티를 `User`와 연관 관계 분리하면서 생긴 오류입니다.
- 유저 생성 시 유저의 약관동의 정보도 함께 저장되어야 하는데 저장이 되고 있지 않습니다.
- 최초 약관동의 상태는 false입니다.

## Issue
resolves #286 


