### PR TITLE
refactor: Dockerfile 이미지 빌드 속도 개선

### DIFF
--- a/scripts/compose.sh
+++ b/scripts/compose.sh
@@ -2,9 +2,8 @@
 
 cd "$(dirname "$0")/.."
 docker compose down -v
-docker rmi withiy-server-server --force
 
-if docker compose build --no-cache; then
+if docker compose build; then
 	echo "Build success!"
 else
 	echo "Build failed..."


### PR DESCRIPTION
### Refactor
- gradlew build 이전에 의존성 캐시를 분리
- Docker 빌드 캐시 허용
- 변경사항이 없어도 매번 이미지를 삭제하는 명령 제거

### Issue
resolves #290 