### PR TITLE
fix: 장소 상세 조회 시 DB 트랜잭션 읽기 전용 해제

### DIFF
--- a/src/main/java/com/server/domain/place/service/PlaceFacade.java
+++ b/src/main/java/com/server/domain/place/service/PlaceFacade.java
@@ -80,7 +80,7 @@ public class PlaceFacade {
 			.toList();
 
 		// 장소 조회시 로그 기록
-		contentVIewLogService.insertContentLog(RouteType.PLACE, placeId);
+		contentViewLogService.insertContentLog(RouteType.PLACE, placeId);
 
 		return GetPlaceDetailResponse.builder()
 			.placeId(place.getId())


### PR DESCRIPTION
장소 상세 조회 시 DB에 장소 조회 로그를 저장하므로 더 이상 읽기 전용이 아니기 때문에 읽기 전용을 해제하였습니다.
