### PR TITLE
fix: Route의 dateSchedule 필드를 설정하지 않음

### DIFF
--- a/src/main/java/com/server/domain/route/entity/Route.java
+++ b/src/main/java/com/server/domain/route/entity/Route.java
@@ -76,6 +76,10 @@ public class Route extends BaseTime {
 		this.status = routeStatus;
 	}
 
+	public void updateDateSchedule(DateSchedule dateSchedule) {
+		this.dateSchedule = dateSchedule;
+	}
+
 	/**
 	 * 새로운 Route 생성
 	 */


### PR DESCRIPTION
### Features
- Route 엔티티 생성 시 dateSchedule 업데이트 로직 추가
- 상위 엔티티(DateSchedule)를 먼저 생성하고, 하위 엔티티(Route)가 이를 참조하도록 엔티티 생성 순서 변경

### Issue
resolves #312 
